### PR TITLE
fix(renderer): disable window framebuffer alpha

### DIFF
--- a/platform/native_renderer.c
+++ b/platform/native_renderer.c
@@ -178,6 +178,9 @@ int NativeRenderer_InitialiseRender(char *windowName, int width, int height, int
 	SDL_SetHint(SDL_HINT_WINDOW_ALLOW_TOPMOST, "0");
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
+	// Prevent compositors from interpreting framebuffer alpha as window transparency.
+	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 0);
+
 	SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 1);
 
 	if (!NativeRenderer_InitialiseGLContext(windowName, fullscreen))


### PR DESCRIPTION
## Description

Disables alpha in the window framebuffer to prevent the compositor from interpreting it as window
transparency.

## Tested on

- **OS:** CachyOS 7.0.12-1
- **Desktop:** KDE Plasma 6.27
- **Display server:** Wayland

## Before


https://github.com/user-attachments/assets/66e348dc-00c5-442f-b1fc-113a72c127f8



## After


https://github.com/user-attachments/assets/fc7521fd-faf1-4b15-9cc5-3315b8d342cd


