### PR TITLE
Make sized enums more portable.

### DIFF
--- a/game/GhostReplay.c
+++ b/game/GhostReplay.c
@@ -1,13 +1,14 @@
 #include <common.h>
 
-typedef enum GhostOpcode : u8
+enum
 {
 	GHOST_OP_POSITION = 0x80,
 	GHOST_OP_ANIMATION,
 	GHOST_OP_BOOST,
 	GHOST_OP_INSTANCE,
 	GHOST_OP_IDLE,
-} GhostOpcode;
+};
+typedef u8 GhostOpcode;
 
 static const u8 GHOST_SIZE_POSITION = 11;
 static const u8 GHOST_SIZE_ANIMATION = 3;

--- a/include/namespace_Camera.h
+++ b/include/namespace_Camera.h
@@ -79,7 +79,7 @@ struct CameraHeightSmoothing
 	s16 currentOffset;
 };
 
-typedef enum CameraFlags : u32
+enum
 {
 	CAMERA_FLAG_RESET_RAIN_POS = 0x1,
 	CAMERA_FLAG_BATTLE_END_OF_RACE = 0x4,
@@ -95,7 +95,8 @@ typedef enum CameraFlags : u32
 	CAMERA_FLAG_ARCADE_END_OF_RACE_ACTIVE = 0x1000,
 	CAMERA_FLAG_FROZEN = 0x8000,
 	CAMERA_FLAG_REVERSE = 0x10000,
-} CameraFlags;
+};
+typedef u32 CameraFlags;
 
 struct CameraDC
 {

--- a/include/namespace_Cdsys.h
+++ b/include/namespace_Cdsys.h
@@ -17,14 +17,15 @@ enum DiscMode
 	DM_AUDIO
 };
 
-typedef enum XAState : int
+enum
 {
 	XA_IDLE = 0,
 	XA_SEEKING = 1,
 	XA_STARTING = 2,
 	XA_PLAYING = 3,
 	XA_FADING = 4,
-} XAState;
+};
+typedef int XAState;
 
 struct XNF
 {

--- a/include/namespace_Coll.h
+++ b/include/namespace_Coll.h
@@ -10,7 +10,7 @@ enum CollFixedPoint
 	COLL_FRACTION_INVALID = -FP_ONE,
 };
 
-typedef enum CollSearchFlags : u16
+enum
 {
 	COLL_SEARCH_TEST_INSTANCES = 0x1,
 	COLL_SEARCH_HIGH_LOD = 0x2,
@@ -18,9 +18,10 @@ typedef enum CollSearchFlags : u16
 	COLL_SEARCH_WALL_PROJECTION_DONE = 0x10,
 	COLL_SEARCH_REPEAT_SCRUB = 0x20,
 	COLL_SEARCH_FORCE_INSTANCE_HIT = 0x40,
-} CollSearchFlags;
+};
+typedef u16 CollSearchFlags;
 
-typedef enum CollStepFlags : u32
+enum
 {
 	// NOTE(aalhendi): Trigger quads OR their terrain_type byte into this
 	// word; low bits are packed trigger payload, not ordinary terrain.
@@ -35,7 +36,8 @@ typedef enum CollStepFlags : u32
 	COLL_STEP_TRIGGER_TURBO_PAD_MASK = COLL_STEP_TRIGGER_TURBO_PAD | COLL_STEP_TRIGGER_SUPER_TURBO_PAD,
 	COLL_STEP_FLAG_KILL_PLANE = 0x4000,
 	COLL_STEP_FLAG_WATER_BSP = 0x8000,
-} CollStepFlags;
+};
+typedef u32 CollStepFlags;
 
 enum CollModelIDFlags
 {
@@ -43,12 +45,13 @@ enum CollModelIDFlags
 	COLL_MODELID_BLOCKAGE_FLAG = 0x8000,
 };
 
-typedef enum CollNormalAxis : s16
+enum
 {
 	COLL_NORMAL_AXIS_Z = 1,
 	COLL_NORMAL_AXIS_X = 2,
 	COLL_NORMAL_AXIS_Y = 3,
-} CollNormalAxis;
+};
+typedef s16 CollNormalAxis;
 
 enum CollQuadTriangleId
 {
@@ -64,7 +67,7 @@ enum CollQuadTriangleId
 	COLL_QUAD_TRIANGLE_HI_7 = 9,
 };
 
-typedef enum CollTriangleClipResult : s8
+enum
 {
 	COLL_TRIANGLE_CLIP_MISS = -1,
 	COLL_TRIANGLE_CLIP_V1 = 0,
@@ -74,7 +77,8 @@ typedef enum CollTriangleClipResult : s8
 	COLL_TRIANGLE_CLIP_V3 = 4,
 	COLL_TRIANGLE_CLIP_EDGE_V1_V3 = 5,
 	COLL_TRIANGLE_CLIP_FACE = 6,
-} CollTriangleClipResult;
+};
+typedef s8 CollTriangleClipResult;
 
 struct CollPlane
 {

--- a/include/namespace_Howl.h
+++ b/include/namespace_Howl.h
@@ -7,7 +7,7 @@ struct SndVolume
 };
 #endif
 
-typedef enum AudioState : s16
+enum
 {
 	AUDIO_NONE = 0,
 	AUDIO_LOADING = 1,
@@ -24,7 +24,8 @@ typedef enum AudioState : s16
 	AUDIO_POST_LAST_LAP = 14,
 	AUDIO_LAST_LAP = 15,
 	AUDIO_RACE_END = 16,
-} AudioState;
+};
+typedef s16 AudioState;
 
 // Global song indices into howl_songOffsets[].
 enum HowlSong

--- a/include/namespace_Level.h
+++ b/include/namespace_Level.h
@@ -157,7 +157,7 @@ struct PVS
 
 typedef s16 BspChildId;
 
-typedef enum QuadBlockFlags : u16
+enum
 {
 	QUADBLOCK_FLAG_REFLECT_SPLIT_LINE_1 = 0x0001,
 	QUADBLOCK_FLAG_LOW_GRAVITY = 0x0002,
@@ -172,7 +172,8 @@ typedef enum QuadBlockFlags : u16
 	QUADBLOCK_FLAG_COLLISION_SURFACE = 0x2000,
 	QUADBLOCK_FLAG_NO_CAMERA_RESPAWN_PROBE = 0x4000,
 	QUADBLOCK_FLAG_SKIP_WATER_LIST = 0x8000,
-} QuadBlockFlags;
+};
+typedef u16 QuadBlockFlags;
 
 enum QuadBlockTriNormalDividendIndex
 {
@@ -367,38 +368,43 @@ struct BSP
 	// 0x20 bytes large
 };
 
-typedef enum BspChildIdEncoding : u16
+enum
 {
 	BSP_CHILD_ID_INDEX_MASK = 0x3fff,
 	BSP_CHILD_ID_LEAF_FLAG = 0x4000,
 	BSP_CHILD_ID_NONE = 0xffff,
-} BspChildIdEncoding;
+};
+typedef u16 BspChildIdEncoding;
 
-typedef enum BspNodeFlag : u16
+enum
 {
 	BSP_NODE_FLAG_LEAF = 0x0001,
-} BspNodeFlag;
+};
+typedef u16 BspNodeFlag;
 
-typedef enum BspRenderLeafFlag : u16
+enum
 {
 	BSP_RENDER_LEAF_FLAG_4X1 = 0x0008,
 	BSP_RENDER_LEAF_FLAG_4X2 = 0x0010,
 	BSP_RENDER_LEAF_FLAG_DYNAMIC_SUBDIV = 0x0020,
 	BSP_RENDER_LEAF_FLAG_4X4 = 0x0080,
-} BspRenderLeafFlag;
+};
+typedef u16 BspRenderLeafFlag;
 
-typedef enum BspHitboxFlag : u16
+enum
 {
 	BSP_HITBOX_LINC_USES_INSTDEF = 0x10,
 	BSP_HITBOX_CHECK_Y_RANGE = 0x20,
 	BSP_HITBOX_USE_Y_AXIS = 0x40,
 	BSP_HITBOX_COLLIDABLE = 0x80,
-} BspHitboxFlag;
+};
+typedef u16 BspHitboxFlag;
 
-typedef enum BspLeafFlag : u16
+enum
 {
 	BSP_LEAF_FLAG_WATER = 0x2,
-} BspLeafFlag;
+};
+typedef u16 BspLeafFlag;
 
 enum BspHitboxClass
 {

--- a/include/namespace_Main.h
+++ b/include/namespace_Main.h
@@ -40,7 +40,7 @@ enum GameMode1
 // TODO(aalhendi): i'd *like* to do something better. idk yet
 #define IS_BOSS_RACE(gm) ((gm) < 0)
 
-typedef enum LoadStage : s32
+enum
 {
 	LOAD_VLC = -6,         // loading VLC table (menu/scrapbook)
 	LOAD_RESTART = -5,     // restart race from pause
@@ -48,7 +48,8 @@ typedef enum LoadStage : s32
 	LOAD_FINISHED = -2,    // TenStages done, transitioning to next phase
 	LOAD_IDLE = -1,        // not loading
 	LOAD_TEN_STAGES_0 = 0, // begin TenStages pipeline
-} LoadStage;
+};
+typedef s32 LoadStage;
 
 _Static_assert(sizeof(LoadStage) == 0x4);
 _Static_assert(LOAD_VLC == -6);
@@ -58,7 +59,7 @@ _Static_assert(LOAD_FINISHED == -2);
 _Static_assert(LOAD_IDLE == -1);
 _Static_assert(LOAD_TEN_STAGES_0 == 0);
 
-typedef enum MainMenuState : s16
+enum
 {
 	MAIN_MENU_TITLE = 0,
 	MAIN_MENU_CHARACTERS = 1,
@@ -66,7 +67,8 @@ typedef enum MainMenuState : s16
 	MAIN_MENU_BATTLE_SETUP = 3,
 	MAIN_MENU_ADVENTURE = 4,
 	MAIN_MENU_SCRAPBOOK = 5,
-} MainMenuState;
+};
+typedef s16 MainMenuState;
 
 enum GameModeEnd
 {

--- a/include/namespace_Proc.h
+++ b/include/namespace_Proc.h
@@ -43,11 +43,12 @@ enum THREAD_BUCKET
 	NUM_BUCKETS // 0x12
 };
 
-typedef enum ThreadFlags : u32
+enum
 {
 	THREAD_FLAG_DEAD = 0x0800,
 	THREAD_FLAG_DISABLE_COLLISION = 0x1000,
-} ThreadFlags;
+};
+typedef u32 ThreadFlags;
 
 enum
 {

--- a/include/namespace_Vehicle.h
+++ b/include/namespace_Vehicle.h
@@ -56,26 +56,29 @@ enum KartState
 	KS_FREEZE = 11
 };
 
-typedef enum RevEngineChargeState : u8
+enum
 {
 	REV_ENGINE_CHARGE_IDLE = 0,
 	REV_ENGINE_CHARGE_RELEASED_ABOVE_ACCEL = 1,
 	REV_ENGINE_CHARGE_ACTIVE = 2,
-} RevEngineChargeState;
+};
+typedef u8 RevEngineChargeState;
 
-typedef enum RevEngineLockoutFlags : u8
+enum
 {
 	REV_ENGINE_LOCKOUT_PEDAL_HELD = 0x1,
 	REV_ENGINE_LOCKOUT_REV_DECAY = 0x2,
 	REV_ENGINE_LOCKOUT_ALL = REV_ENGINE_LOCKOUT_PEDAL_HELD | REV_ENGINE_LOCKOUT_REV_DECAY,
-} RevEngineLockoutFlags;
+};
+typedef u8 RevEngineLockoutFlags;
 
-typedef enum EngineSoundMode : u8
+enum
 {
 	ENGINE_SOUND_FADE_OUT = 0,
 	ENGINE_SOUND_FADE_IN = 1,
 	ENGINE_SOUND_DYNAMIC = 2,
-} EngineSoundMode;
+};
+typedef u8 EngineSoundMode;
 
 enum RevEnginePackedStatusMask
 {
@@ -472,7 +475,7 @@ enum EngineClass
 	NUM_CLASSES
 };
 
-typedef enum Actions : u32
+enum
 {
 	ACTION_TOUCH_GROUND = 0x1,
 	ACTION_STARTED_TOUCH_GROUND = 0x2,
@@ -506,17 +509,19 @@ typedef enum Actions : u32
 	ACTION_REVERSE_STEER_LEFT = 0x20000000,
 	ACTION_REVERSE_STEER_RIGHT = 0x40000000,
 	ACTION_DROPPING_MINE = 0x80000000u,
-} Actions;
+};
+typedef u32 Actions;
 
-typedef enum DriverCollisionFlags : s16
+enum
 {
 	DRIVER_COLL_FLAG_MASK_GRAB_REQUEST = 0x1,
 	DRIVER_COLL_FLAG_SURFACE_PUSHBACK = 0x2,
 	DRIVER_COLL_FLAG_TOUCHED_QUADBLOCK = 0x4,
 	DRIVER_COLL_FLAG_GROUNDED = 0x8,
-} DriverCollisionFlags;
+};
+typedef s16 DriverCollisionFlags;
 
-typedef enum RainCloudEffect : s16
+enum
 {
 	RAIN_CLOUD_EFFECT_SLOW = 0,
 	RAIN_CLOUD_EFFECT_ITEM_ROLL = 1,
@@ -525,14 +530,16 @@ typedef enum RainCloudEffect : s16
 	RAIN_CLOUD_EFFECT_NONE = 4,
 	RAIN_CLOUD_EFFECT_HEAVY_FRICTION = 5,
 	RAIN_CLOUD_EFFECT_RESERVE_RELEASE = 6,
-} RainCloudEffect;
+};
+typedef s16 RainCloudEffect;
 
-typedef enum ForcedJumpType : u8
+enum
 {
 	FORCED_JUMP_NONE = 0,
 	FORCED_JUMP_LOW = 1,
 	FORCED_JUMP_HIGH = 2,
-} ForcedJumpType;
+};
+typedef u8 ForcedJumpType;
 
 enum BotFlags
 {

--- a/include/ovr_230.h
+++ b/include/ovr_230.h
@@ -1,11 +1,12 @@
-typedef enum ScrapbookState : s32
+enum
 {
 	SCRAP_INIT = 0,
 	SCRAP_LOAD = 1,
 	SCRAP_PLAY = 2,
 	SCRAP_STOP = 3,
 	SCRAP_EXIT = 4,
-} ScrapbookState;
+};
+typedef s32 ScrapbookState;
 
 enum TransitionState
 {

--- a/include/ovr_233.h
+++ b/include/ovr_233.h
@@ -1,5 +1,4 @@
-
-typedef enum CutscenePhase : s32
+enum
 {
 	CS_CAMERA_PAN = 0,
 	CS_WAIT_INPUT = 1,
@@ -7,7 +6,8 @@ typedef enum CutscenePhase : s32
 	CS_LOADING = 3,
 	CS_FADE_IN = 4,
 	CS_WAIT_END = 5,
-} CutscenePhase;
+};
+typedef s32 CutscenePhase;
 
 struct CsThreadInitData
 {

--- a/include/regionsEXE.h
+++ b/include/regionsEXE.h
@@ -7,15 +7,16 @@ struct MatrixND
 	int t[3];
 };
 
-typedef enum ScrubFlags : u32
+enum
 {
 	SCRUB_FLAG_APPLY_IMPACT = 0x1,
 	SCRUB_FLAG_SLAM_ON_HARD_IMPACT = 0x2,
 	SCRUB_FLAG_SKIP_WALL_RUB_TIMER = 0x4,
 	SCRUB_FLAG_KEEP_RESERVES = 0x8,
-} ScrubFlags;
+};
+typedef u32 ScrubFlags;
 
-typedef enum TerrainFlags : u32
+enum
 {
 	TERRAIN_FLAG_RAISE_GROUND_OFFSET = 0x1,
 	TERRAIN_FLAG_ACCEL_WHILE_REVERSE_SLIDING = 0x4,
@@ -25,12 +26,14 @@ typedef enum TerrainFlags : u32
 	TERRAIN_FLAG_LANDING_SPARKS = 0x40,
 	TERRAIN_FLAG_MUD_PHYSICS = 0x80,
 	TERRAIN_FLAG_SIDESLIP_FRICTION = 0x100,
-} TerrainFlags;
+};
+typedef u32 TerrainFlags;
 
-typedef enum TerrainBotFlags : u16
+enum
 {
 	TERRAIN_BOT_FLAG_DECEL_TO_TARGET_SPEED = 0x80,
-} TerrainBotFlags;
+};
+typedef u16 TerrainBotFlags;
 
 struct Scrub
 {


### PR DESCRIPTION
With this change, enums won't use anymore C23+ feature, allowing for older compilers to work just fine with the source. (Required for example for GCC 10.3.0 support)