### PR TITLE
Fix ptr_waterEnvMap declaration

### DIFF
--- a/game/226/226_00_DrawLevelOvr1P.c
+++ b/game/226/226_00_DrawLevelOvr1P.c
@@ -10351,7 +10351,7 @@ static int DrawLevelOvr1P_DrawWaterListQuadBlock(struct PushBuffer *pb, struct P
 
 static void Ovr226_800a1e30_SeedWaterListState(void)
 {
-	struct TextureLayout* waterEnvMap = DrawLevelOvr1P_Scratch()->waterEnvMapPtr32;
+	const struct TextureLayout *waterEnvMap = (const struct TextureLayout *)(uintptr_t)DrawLevelOvr1P_Scratch()->waterEnvMapPtr32;
 
 	// NOTE(aalhendi): Retail 0x800a1e30 uses the global 1P retry list, not the
 	// current render-list field, before walking the water BSP list.
@@ -10362,10 +10362,8 @@ static void Ovr226_800a1e30_SeedWaterListState(void)
 	CTC2(0, 21);
 	CTC2(0, 22);
 	CTC2(0, 23);
-	
-	//need to cast as pointer because uv.uv0 / uv.uv1 was declared as u32 instead of u8 -penta3
-	DrawLevelOvr1P_Scratch()->uv.uv0 = *(u32*)&waterEnvMap->u0;
-	DrawLevelOvr1P_Scratch()->uv.uv1 = *(u32*)&waterEnvMap->u1;
+	DrawLevelOvr1P_Scratch()->uv.uv0 = DrawLevelOvr1P_ReadPackedWord((const u8 *)waterEnvMap + 0);
+	DrawLevelOvr1P_Scratch()->uv.uv1 = DrawLevelOvr1P_ReadPackedWord((const u8 *)waterEnvMap + 4);
 }
 
 static void Ovr226_800a1e74_SeedWaterVisibilityScratch(const int *visFaceList, const struct QuadBlock *block)
@@ -11063,7 +11061,8 @@ static int Ovr226_800a0e10_DispatchBucketTable(struct DrawLevelOvr1PRenderList *
 	return 1;
 }
 
-static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, struct TextureLayout* waterEnvMap)
+static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
+                                 const struct TextureLayout *waterEnvMap)
 {
 	struct DrawLevelOvr1PRenderList *renderList = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -11083,7 +11082,7 @@ static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 		return 1;
 	}
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
 
 	if (mesh->ptrQuadBlockArray == NULL)
 	{
@@ -11116,19 +11115,20 @@ static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x800a0cbc-0x800ab970
-void DrawLevelOvr1P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, struct TextureLayout* waterEnvMap)
+void DrawLevelOvr1P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
+                    const struct TextureLayout *waterEnvMap)
 {
 	(void)Ovr226_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, waterEnvMap);
 }
 
 void DrawLevelOvr3P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14, void *VisMem18,
-                    struct TextureLayout* waterEnvMap)
+                    const struct TextureLayout *waterEnvMap)
 {
 	(void)Ovr228_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, waterEnvMap);
 }
 
 void DrawLevelOvr4P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14, void *VisMem18,
-                    void *VisMem1C, struct TextureLayout* waterEnvMap)
+                    void *VisMem1C, const struct TextureLayout *waterEnvMap)
 {
 	(void)Ovr229_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, VisMem1C, waterEnvMap);
 }

--- a/game/226/226_00_DrawLevelOvr1P.c
+++ b/game/226/226_00_DrawLevelOvr1P.c
@@ -9227,7 +9227,7 @@ static int DrawLevelOvr1P_DrawWaterListQuadBlock(struct PushBuffer *pb, struct P
 
 static void Ovr226_800a1e30_SeedWaterListState(void)
 {
-	u32 *waterEnvMap = (u32 *)(uintptr_t)DrawLevelOvr1P_Scratch()->waterEnvMapPtr32;
+	struct TextureLayout* waterEnvMap = DrawLevelOvr1P_Scratch()->waterEnvMapPtr32;
 
 	// NOTE(aalhendi): Retail 0x800a1e30 uses the global 1P retry list, not the
 	// current render-list field, before walking the water BSP list.
@@ -9236,8 +9236,10 @@ static void Ovr226_800a1e30_SeedWaterListState(void)
 	CTC2(0, 21);
 	CTC2(0, 22);
 	CTC2(0, 23);
-	DrawLevelOvr1P_Scratch()->uv.uv0 = waterEnvMap[0];
-	DrawLevelOvr1P_Scratch()->uv.uv1 = waterEnvMap[1];
+	
+	//need to cast as pointer because uv.uv0 / uv.uv1 was declared as u32 instead of u8 -penta3
+	DrawLevelOvr1P_Scratch()->uv.uv0 = *(u32*)&waterEnvMap->u0;
+	DrawLevelOvr1P_Scratch()->uv.uv1 = *(u32*)&waterEnvMap->u1;
 }
 
 static void Ovr226_800a1e74_SeedWaterVisibilityScratch(const int *visFaceList, const struct QuadBlock *block)
@@ -9817,7 +9819,7 @@ static int Ovr226_800a0e10_DispatchBucketTable(struct DrawLevelOvr1PRenderList *
 	return 1;
 }
 
-static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *waterEnvMap)
+static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, struct TextureLayout* waterEnvMap)
 {
 	struct DrawLevelOvr1PRenderList *renderList = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -9835,7 +9837,7 @@ static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 	if (VisMem10 == NULL)
 		return 1;
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
 
 	if (mesh->ptrQuadBlockArray == NULL)
 		return 1;
@@ -9862,19 +9864,19 @@ static int Ovr226_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x800a0cbc-0x800ab970
-void DrawLevelOvr1P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *waterEnvMap)
+void DrawLevelOvr1P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, struct TextureLayout* waterEnvMap)
 {
 	(void)Ovr226_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, waterEnvMap);
 }
 
 void DrawLevelOvr3P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14, void *VisMem18,
-                    void *waterEnvMap)
+                    struct TextureLayout* waterEnvMap)
 {
 	(void)Ovr228_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, waterEnvMap);
 }
 
 void DrawLevelOvr4P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14, void *VisMem18,
-                    void *VisMem1C, void *waterEnvMap)
+                    void *VisMem1C, struct TextureLayout* waterEnvMap)
 {
 	(void)Ovr229_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, VisMem1C, waterEnvMap);
 }

--- a/game/227/227_00_DrawLevelOvr2P.c
+++ b/game/227/227_00_DrawLevelOvr2P.c
@@ -228,7 +228,7 @@ static int Ovr227_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 	if ((VisMem10 == NULL) || (VisMem14 == NULL))
 		return 1;
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
 	DrawLevelOvr1P_Scratch()->pushBufferPtr32[0] = (u32)(uintptr_t)&pb[0];
 	DrawLevelOvr1P_Scratch()->pushBufferPtr32[1] = (u32)(uintptr_t)&pb[1];
 	DrawLevelOvr1P_Scratch()->playerClipCursorPtr32[0] = (u32)(uintptr_t)clipCursors[0];

--- a/game/227/227_00_DrawLevelOvr2P.c
+++ b/game/227/227_00_DrawLevelOvr2P.c
@@ -248,7 +248,7 @@ static int Ovr227_ConsumeClipRecordsForViewport(struct PushBuffer *pb, struct Pr
 }
 
 static int Ovr227_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                                 void *waterEnvMap)
+                                 const struct TextureLayout *waterEnvMap)
 {
 	struct DrawLevelOvr1PRenderList *renderLists = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -270,7 +270,7 @@ static int Ovr227_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, str
 		return 1;
 	}
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
 	DrawLevelOvr1P_Scratch()->pushBufferPtr32[0] = (u32)(uintptr_t)&pb[0];
 	DrawLevelOvr1P_Scratch()->pushBufferPtr32[1] = (u32)(uintptr_t)&pb[1];
 	DrawLevelOvr1P_Scratch()->playerClipCursorPtr32[0] = (u32)(uintptr_t)clipCursors[0];
@@ -318,7 +318,8 @@ static void Ovr227_800ab45c_CopyClipRecordJumpTable(void)
 	}
 }
 
-void DrawLevelOvr2P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14, void *waterEnvMap)
+void DrawLevelOvr2P(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
+                    const struct TextureLayout *waterEnvMap)
 {
 	(void)Ovr227_800a0cbc_Entry(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, waterEnvMap);
 }

--- a/game/228/228_00_DrawLevelOvr3P.c
+++ b/game/228/228_00_DrawLevelOvr3P.c
@@ -411,7 +411,8 @@ static int Ovr228_800a81bc_ConsumeClipRecords(struct PushBuffer *pb, struct Prim
 }
 
 static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
-                                              void *VisMem14, void *VisMem18, struct TextureLayout* waterEnvMap, Ovr228BucketDispatch dispatch, Ovr228ClipConsumer consume)
+                                              void *VisMem14, void *VisMem18, const struct TextureLayout *waterEnvMap, Ovr228BucketDispatch dispatch,
+                                              Ovr228ClipConsumer consume)
 {
 	struct DrawLevelOvr1PRenderList *renderLists = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -443,7 +444,7 @@ static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 		return 1;
 	}
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
 	DrawLevelOvr1P_Scratch()->primMemEndPtr32 = (u32)(uintptr_t)primMem->end;
 
 	if (mesh->ptrQuadBlockArray == NULL)
@@ -497,7 +498,7 @@ static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 }
 
 int Ovr228_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, struct TextureLayout* waterEnvMap)
+                          void *VisMem18, const struct TextureLayout *waterEnvMap)
 {
 	return Ovr228_800a0cbc_EntryWithCallbacks(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, waterEnvMap,
 	                                          Ovr228_800a10c4_800a81bc_BucketDispatch, Ovr228_800a81bc_ConsumeClipRecords);

--- a/game/228/228_00_DrawLevelOvr3P.c
+++ b/game/228/228_00_DrawLevelOvr3P.c
@@ -349,7 +349,7 @@ static int Ovr228_800a81bc_ConsumeClipRecords(struct PushBuffer *pb, struct Prim
 }
 
 static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
-                                              void *VisMem14, void *VisMem18, void *waterEnvMap, Ovr228BucketDispatch dispatch, Ovr228ClipConsumer consume)
+                                              void *VisMem14, void *VisMem18, struct TextureLayout* waterEnvMap, Ovr228BucketDispatch dispatch, Ovr228ClipConsumer consume)
 {
 	struct DrawLevelOvr1PRenderList *renderLists = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -375,7 +375,7 @@ static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 	if (VisMem18 == NULL)
 		return 1;
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
 	DrawLevelOvr1P_Scratch()->primMemEndPtr32 = (u32)(uintptr_t)primMem->end;
 
 	if (mesh->ptrQuadBlockArray == NULL)
@@ -419,7 +419,7 @@ static int Ovr228_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 }
 
 int Ovr228_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *waterEnvMap)
+                          void *VisMem18, struct TextureLayout* waterEnvMap)
 {
 	return Ovr228_800a0cbc_EntryWithCallbacks(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, waterEnvMap,
 	                                          Ovr228_800a10c4_800a81bc_BucketDispatch, Ovr228_800a81bc_ConsumeClipRecords);

--- a/game/229/229_00_DrawLevelOvr4P.c
+++ b/game/229/229_00_DrawLevelOvr4P.c
@@ -354,7 +354,7 @@ static int Ovr229_800a8270_ConsumeClipRecords(struct PushBuffer *pb, struct Prim
 }
 
 static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
-                                              void *VisMem14, void *VisMem18, void *VisMem1C, void *waterEnvMap, Ovr229BucketDispatch dispatch,
+                                              void *VisMem14, void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap, Ovr229BucketDispatch dispatch,
                                               Ovr229ClipConsumer consume)
 {
 	struct DrawLevelOvr1PRenderList *renderLists = LevRenderList;
@@ -386,7 +386,7 @@ static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 	if (VisMem1C == NULL)
 		return 1;
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
 	DrawLevelOvr1P_Scratch()->primMemEndPtr32 = (u32)(uintptr_t)primMem->end;
 
 	if (mesh->ptrQuadBlockArray == NULL)
@@ -437,7 +437,7 @@ static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 }
 
 int Ovr229_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *VisMem1C, void *waterEnvMap)
+                          void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap)
 {
 	return Ovr229_800a0cbc_EntryWithCallbacks(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, VisMem1C, waterEnvMap,
 	                                          Ovr229_800a1178_800a8270_BucketDispatch, Ovr229_800a8270_ConsumeClipRecords);

--- a/game/229/229_00_DrawLevelOvr4P.c
+++ b/game/229/229_00_DrawLevelOvr4P.c
@@ -418,8 +418,8 @@ static int Ovr229_800a8270_ConsumeClipRecords(struct PushBuffer *pb, struct Prim
 }
 
 static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10,
-                                              void *VisMem14, void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap, Ovr229BucketDispatch dispatch,
-                                              Ovr229ClipConsumer consume)
+                                              void *VisMem14, void *VisMem18, void *VisMem1C, const struct TextureLayout *waterEnvMap,
+                                              Ovr229BucketDispatch dispatch, Ovr229ClipConsumer consume)
 {
 	struct DrawLevelOvr1PRenderList *renderLists = LevRenderList;
 	struct mesh_info *mesh = (struct mesh_info *)bspList;
@@ -458,7 +458,7 @@ static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 		return 1;
 	}
 
-	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = waterEnvMap;
+	DrawLevelOvr1P_Scratch()->waterEnvMapPtr32 = (u32)(uintptr_t)waterEnvMap;
 	DrawLevelOvr1P_Scratch()->primMemEndPtr32 = (u32)(uintptr_t)primMem->end;
 
 	if (mesh->ptrQuadBlockArray == NULL)
@@ -521,7 +521,7 @@ static int Ovr229_800a0cbc_EntryWithCallbacks(void *LevRenderList, struct PushBu
 }
 
 int Ovr229_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap)
+                          void *VisMem18, void *VisMem1C, const struct TextureLayout *waterEnvMap)
 {
 	return Ovr229_800a0cbc_EntryWithCallbacks(LevRenderList, pb, bspList, primMem, VisMem10, VisMem14, VisMem18, VisMem1C, waterEnvMap,
 	                                          Ovr229_800a1178_800a8270_BucketDispatch, Ovr229_800a8270_ConsumeClipRecords);

--- a/game/RenderLevel/AnimateWater.c
+++ b/game/RenderLevel/AnimateWater.c
@@ -138,7 +138,15 @@ void AnimateWaterVertex(struct WaterVert *waterVert, u16 colorOffset, int firstO
 	*(u32 *)&levVert->color_hi[0] = (color << 16) | (color << 8) | color;
 }
 
-static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int numLists, int **visLists)
+static u16 AnimateWater_ReadTextureHalf(const struct TextureLayout *layout, int offset)
+{
+	const u8 *bytes = (const u8 *)layout + offset;
+
+	return (u16)((u16)bytes[0] | ((u16)bytes[1] << 8));
+}
+
+static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVert *waterVert, const struct TextureLayout *waterEnvMap, int numLists,
+                                int **visLists)
 {
 #if defined(CTR_NATIVE)
 	// NOTE(aalhendi): CTR_NATIVE divergence, not retail ASM: native tracks can
@@ -147,7 +155,7 @@ static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVer
 		return;
 #endif
 
-	u16 colorOffset = *(u16 *)waterEnvMap;
+	u16 colorOffset = AnimateWater_ReadTextureHalf(waterEnvMap, 0);
 	u32 visBits = 0;
 	u32 *visList[4];
 	int firstFrame;
@@ -194,28 +202,30 @@ static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVer
 	}
 }
 
-void AnimateWater1P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5)
+void AnimateWater1P(int timer, int numWaterVertices, struct WaterVert *waterVert, const struct TextureLayout *waterEnvMap, int *param_5)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d79c-0x8006d864.
 	int *visLists[1] = {param_5};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 1, visLists);
 }
 
-void AnimateWater2P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6)
+void AnimateWater2P(int timer, int numWaterVertices, struct WaterVert *waterVert, const struct TextureLayout *waterEnvMap, int *param_5, int *param_6)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d864-0x8006d948.
 	int *visLists[2] = {param_5, param_6};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 2, visLists);
 }
 
-void AnimateWater3P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6, int *param_7)
+void AnimateWater3P(int timer, int numWaterVertices, struct WaterVert *waterVert, const struct TextureLayout *waterEnvMap, int *param_5, int *param_6,
+                    int *param_7)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d948-0x8006da50.
 	int *visLists[3] = {param_5, param_6, param_7};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 3, visLists);
 }
 
-void AnimateWater4P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6, int *param_7, int *param_8)
+void AnimateWater4P(int timer, int numWaterVertices, struct WaterVert *waterVert, const struct TextureLayout *waterEnvMap, int *param_5, int *param_6,
+                    int *param_7, int *param_8)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006da50-0x8006db7c.
 	int *visLists[4] = {param_5, param_6, param_7, param_8};

--- a/game/RenderLevel/AnimateWater.c
+++ b/game/RenderLevel/AnimateWater.c
@@ -138,7 +138,7 @@ void AnimateWaterVertex(struct WaterVert *waterVert, u16 colorOffset, int firstO
 	*(u32 *)&levVert->color_hi[0] = (color << 16) | (color << 8) | color;
 }
 
-static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVert *waterVert, void *waterEnvMap, int numLists, int **visLists)
+static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int numLists, int **visLists)
 {
 #if defined(CTR_NATIVE)
 	// NOTE(aalhendi): CTR_NATIVE divergence, not retail ASM: native tracks can
@@ -194,28 +194,28 @@ static void AnimateWater_Common(int timer, int numWaterVertices, struct WaterVer
 	}
 }
 
-void AnimateWater1P(int timer, int numWaterVertices, struct WaterVert *waterVert, void *waterEnvMap, int *param_5)
+void AnimateWater1P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d79c-0x8006d864.
 	int *visLists[1] = {param_5};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 1, visLists);
 }
 
-void AnimateWater2P(int timer, int numWaterVertices, struct WaterVert *waterVert, void *waterEnvMap, int *param_5, int *param_6)
+void AnimateWater2P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d864-0x8006d948.
 	int *visLists[2] = {param_5, param_6};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 2, visLists);
 }
 
-void AnimateWater3P(int timer, int numWaterVertices, struct WaterVert *waterVert, void *waterEnvMap, int *param_5, int *param_6, int *param_7)
+void AnimateWater3P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6, int *param_7)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006d948-0x8006da50.
 	int *visLists[3] = {param_5, param_6, param_7};
 	AnimateWater_Common(timer, numWaterVertices, waterVert, waterEnvMap, 3, visLists);
 }
 
-void AnimateWater4P(int timer, int numWaterVertices, struct WaterVert *waterVert, void *waterEnvMap, int *param_5, int *param_6, int *param_7, int *param_8)
+void AnimateWater4P(int timer, int numWaterVertices, struct WaterVert *waterVert, struct TextureLayout* waterEnvMap, int *param_5, int *param_6, int *param_7, int *param_8)
 {
 	// NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006da50-0x8006db7c.
 	int *visLists[4] = {param_5, param_6, param_7, param_8};

--- a/include/functions.h
+++ b/include/functions.h
@@ -84,9 +84,9 @@ void DropRain_MakeSound(struct GameTracker *gGT);
 void DropRain_Reset(struct GameTracker *gGT);
 
 int Ovr228_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, struct TextureLayout* waterEnvMap);
+                          void *VisMem18, const struct TextureLayout *waterEnvMap);
 int Ovr229_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap);
+                          void *VisMem18, void *VisMem1C, const struct TextureLayout *waterEnvMap);
 
 void EngineSound_Player(struct Driver *driver);
 int EngineSound_VolumeAdjust(int desired, int current, int step);

--- a/include/functions.h
+++ b/include/functions.h
@@ -84,9 +84,9 @@ void DropRain_MakeSound(struct GameTracker *gGT);
 void DropRain_Reset(struct GameTracker *gGT);
 
 int Ovr228_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *waterEnvMap);
+                          void *VisMem18, struct TextureLayout* waterEnvMap);
 int Ovr229_800a0cbc_Entry(void *LevRenderList, struct PushBuffer *pb, struct BSP *bspList, struct PrimMem *primMem, void *VisMem10, void *VisMem14,
-                          void *VisMem18, void *VisMem1C, void *waterEnvMap);
+                          void *VisMem18, void *VisMem1C, struct TextureLayout* waterEnvMap);
 
 void EngineSound_Player(struct Driver *driver);
 int EngineSound_VolumeAdjust(int desired, int current, int step);

--- a/include/namespace_DrawLevel.h
+++ b/include/namespace_DrawLevel.h
@@ -170,7 +170,7 @@ struct DrawLevelOvr1PStableScratch
 	u32 drawOrderOrHeader;
 	u32 clipRecordHeader;
 	u32 mosaicTextureWord;
-	u32 waterEnvMapPtr32;
+	struct TextureLayout* waterEnvMapPtr32;
 	u8 pad_08c[0x10];
 	u32 previousDirectHandlerAddress;
 	u8 pad_0a0[0x1c];

--- a/include/namespace_DrawLevel.h
+++ b/include/namespace_DrawLevel.h
@@ -170,7 +170,7 @@ struct DrawLevelOvr1PStableScratch
 	u32 drawOrderOrHeader;
 	u32 clipRecordHeader;
 	u32 mosaicTextureWord;
-	struct TextureLayout* waterEnvMapPtr32;
+	u32 waterEnvMapPtr32;
 	u8 pad_08c[0x10];
 	u32 previousDirectHandlerAddress;
 	u8 pad_0a0[0x1c];

--- a/include/namespace_Level.h
+++ b/include/namespace_Level.h
@@ -782,8 +782,8 @@ struct Level
 	struct Icon *ptr_named_tex_array;
 
 	// 0x44
-	// pointer to environment map, used by water rendering
-	void *ptr_tex_waterEnvMap;
+	// pointer to environment map texture layout, used by water rendering
+	struct TextureLayout* ptr_tex_waterEnvMap;
 
 	// 0x48
 	// used for additional skybox gradients (e.g. papu's pyramid)

--- a/include/namespace_Level.h
+++ b/include/namespace_Level.h
@@ -783,7 +783,7 @@ struct Level
 
 	// 0x44
 	// pointer to environment map texture layout, used by water rendering
-	struct TextureLayout* ptr_tex_waterEnvMap;
+	struct TextureLayout *ptr_tex_waterEnvMap;
 
 	// 0x48
 	// used for additional skybox gradients (e.g. papu's pyramid)


### PR DESCRIPTION
waterEnvMap is not void* , it is a pointer to an textureLayout, UV entry on draw overlays can still be cleaned up further tho (unless the assembly really parses it as 4 bytes on the render)