### PR TITLE
Add missing `libxtst-dev` dependency to Debian/Ubuntu build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ That's it. SDL3 is compiled from vendored source -- no separate install needed.
 
 ```
 sudo apt install gcc-multilib
-sudo apt install libx11-dev libxext-dev libgl1-mesa-dev libasound2-dev libudev-dev libdbus-1-dev
+sudo apt install libx11-dev libxext-dev libgl1-mesa-dev libasound2-dev libudev-dev libdbus-1-dev libxtst-dev
 ```
 
 ## Building


### PR DESCRIPTION
This minor PR adds a dependency that was missing from the Debian/Ubuntu-specific build instructions. I ran into it after attempting to run the build script once. After installing `libxtst-dev`, the build completed and worked as expected.