### PR TITLE
fix: allow str track previews to load from bigfile.big

### DIFF
--- a/game/230/MM_TrackSelect.c
+++ b/game/230/MM_TrackSelect.c
@@ -116,7 +116,8 @@ void MM_TrackSelect_Video_Draw(RECT *r, struct MainMenu_LevelRow *selectMenu, in
 	{
 		if ((D230.trackSel_videoStateCurr == 2) && (D230.trackSel_videoStatePrev == 1))
 		{
-			if (NativeSTR_StartTrackPreview(videoID, selectMenu->videoLength) != 0)
+			//modified to read .str files directly from bigfile.big	-penta3		 
+			if (NativeSTR_StartTrackPreview(entry[videoID].offset, selectMenu->videoLength) != 0)
 			{
 				D230.trackSel_video_boolAllocated = D230.trackSel_videoStatePrev;
 			}

--- a/game/230/MM_TrackSelect.c
+++ b/game/230/MM_TrackSelect.c
@@ -116,8 +116,7 @@ void MM_TrackSelect_Video_Draw(RECT *r, struct MainMenu_LevelRow *selectMenu, in
 	{
 		if ((D230.trackSel_videoStateCurr == 2) && (D230.trackSel_videoStatePrev == 1))
 		{
-			//modified to read .str files directly from bigfile.big	-penta3		 
-			if (NativeSTR_StartTrackPreview(entry[videoID].offset, selectMenu->videoLength) != 0)
+			if (NativeSTR_StartTrackPreviewFromBigfileSector(entry[videoID].offset, selectMenu->videoLength) != 0)
 			{
 				D230.trackSel_video_boolAllocated = D230.trackSel_videoStatePrev;
 			}

--- a/include/platform/native_assets.h
+++ b/include/platform/native_assets.h
@@ -15,6 +15,7 @@ int NativeAssets_ResolvePathStr8(NativeStr8 relativePath, char *dst, size_t dstS
 int NativeAssets_ResolvePath(const char *relativePath, char *dst, size_t dstSize);
 FILE *NativeAssets_OpenStr8(NativeStr8 relativePath, const char *mode);
 FILE *NativeAssets_Open(const char *relativePath, const char *mode);
+FILE *NativeAssets_OpenBigfile(const char *mode);
 int NativeAssets_Validate(void);
 
 #endif

--- a/include/platform/native_str.h
+++ b/include/platform/native_str.h
@@ -3,7 +3,7 @@
 
 #include <macros.h>
 
-s32 NativeSTR_StartTrackPreview(s32 bigfileIndex, s32 frameCount);
+s32 NativeSTR_StartTrackPreviewFromBigfileSector(s32 bigfileSector, s32 frameCount);
 s32 NativeSTR_StartScrapbook(void);
 void NativeSTR_Stop(void);
 s32 NativeSTR_UploadNextFrame(s32 dstX, s32 dstY);

--- a/platform/native_assets.c
+++ b/platform/native_assets.c
@@ -669,6 +669,11 @@ FILE *NativeAssets_Open(const char *relativePath, const char *mode)
 	return NativeAssets_OpenStr8(NativeStr8_FromCString(relativePath), mode);
 }
 
+FILE *NativeAssets_OpenBigfile(const char *mode)
+{
+	return NativeAssets_OpenStr8(NATIVE_STR8_LIT(NATIVE_ASSETS_BIGFILE_PATH), mode);
+}
+
 internal int NativeAssets_ReadExact(FILE *file, void *dst, size_t size)
 {
 	return fread(dst, 1, size, file) == size;

--- a/platform/native_str.c
+++ b/platform/native_str.c
@@ -4,7 +4,6 @@
 #include <platform/native_str.h>
 #include <psx/libgpu.h>
 
-
 #include <stdio.h>
 #include <string.h>
 
@@ -17,7 +16,6 @@
 #define NATIVE_STR_MAX_RECORD_SIZE          NATIVE_STR_CD_SECTOR_SIZE
 #define NATIVE_STR_MAX_FRAME_SECTORS        10
 #define NATIVE_STR_MAX_FRAME_BYTES          (NATIVE_STR_MAX_FRAME_SECTORS * NATIVE_STR_CD_SECTOR_PAYLOAD)
-#define NATIVE_STR_PATH_MAX                 1024
 #define NATIVE_STR_MAX_WIDTH                512
 #define NATIVE_STR_MAX_HEIGHT               240
 #define NATIVE_STR_ID                       0x80010160u
@@ -34,10 +32,6 @@ enum NativeSTRFormat
 	NATIVE_STR_FORMAT_CD_STREAM,
 };
 
-//read str track preview files from bigfile.big directly like retail
-//ideally i think we should use native_assets.c macro or something more global -penta3
-#define NATIVE_STR_BIGFILE_PATH             "BIGFILE.BIG"
-
 struct NativeSTRState
 {
 	FILE *file;
@@ -45,7 +39,7 @@ struct NativeSTRState
 	s32 format;
 	s32 loop;
 	s32 bigfileSector;
-	u32 baseOffset;
+	u32 fileBaseOffset;
 	s32 frameIndex;
 	s32 frameLimit;
 	s32 frameSize;
@@ -571,6 +565,17 @@ internal s32 NativeSTR_ReadNextFrameFromCdStream(void)
 	return copied == (s32)firstHeader.frameSize;
 }
 
+internal s32 NativeSTR_RewindFrameSource(void)
+{
+	if (fseek(s_str.file, (long)s_str.fileBaseOffset, SEEK_SET) != 0)
+	{
+		return 0;
+	}
+
+	s_str.frameIndex = 0;
+	return 1;
+}
+
 internal s32 NativeSTR_ReadNextFrame(void)
 {
 	s32 tries;
@@ -585,8 +590,10 @@ internal s32 NativeSTR_ReadNextFrame(void)
 				return 0;
 			}
 
-			fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET);
-			s_str.frameIndex = 0;
+			if (NativeSTR_RewindFrameSource() == 0)
+			{
+				return 0;
+			}
 		}
 
 		if (((s_str.format == NATIVE_STR_FORMAT_CD_STREAM) ? NativeSTR_ReadNextFrameFromCdStream() : NativeSTR_ReadNextFrameFromFile()) != 0)
@@ -600,67 +607,22 @@ internal s32 NativeSTR_ReadNextFrame(void)
 			return 0;
 		}
 
-		fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET);
-		s_str.frameIndex = 0;
-	}
-
-	return 0;
-}
-
-/*
-//Retail does not need "bigfile.txt" to read track previews, it read throught bigfile.bigfile
-//keep this commented since is unused
-internal s32 NativeSTR_ResolveBigfilePath(s32 bigfileIndex, char *dst, s32 dstCount)
-{
-	FILE *file;
-	char line[256];
-	s32 index = 0;
-
-	if ((dst == NULL) || (dstCount <= 0))
-	{
-		return 0;
-	}
-
-	file = NativeAssets_Open("bigfile.txt", "r");
-	if (file == NULL)
-	{
-		return 0;
-	}
-
-	while (fgets(line, sizeof(line), file) != NULL)
-	{
-		if (index == bigfileIndex)
+		if (NativeSTR_RewindFrameSource() == 0)
 		{
-			NativeStr8 lineText = NativeStr8_FromCString(line);
-			char relativePath[256];
-			int written;
-
-			while ((lineText.len != 0) && ((lineText.ptr[lineText.len - 1u] == '\r') || (lineText.ptr[lineText.len - 1u] == '\n')))
-			{
-				lineText.len--;
-			}
-
-			written = snprintf(relativePath, sizeof(relativePath), "bigfile/%.*s", (int)lineText.len, (const char *)lineText.ptr);
-			if ((written <= 0) || ((size_t)written >= sizeof(relativePath)) || !NativeAssets_ResolvePath(relativePath, dst, (size_t)dstCount))
-			{
-				fclose(file);
-				return 0;
-			}
-
-			fclose(file);
-			return 1;
+			return 0;
 		}
-
-		index++;
 	}
 
-	fclose(file);
 	return 0;
 }
-*/
 
-s32 NativeSTR_StartTrackPreview(s32 bigfileSector, s32 frameCount)
+s32 NativeSTR_StartTrackPreviewFromBigfileSector(s32 bigfileSector, s32 frameCount)
 {
+	if (bigfileSector < 0)
+	{
+		return 0;
+	}
+
 	if ((s_str.active != 0) && (s_str.bigfileSector == bigfileSector))
 	{
 		return 1;
@@ -668,14 +630,14 @@ s32 NativeSTR_StartTrackPreview(s32 bigfileSector, s32 frameCount)
 
 	NativeSTR_Stop();
 
-	s_str.file = NativeAssets_Open(NATIVE_STR_BIGFILE_PATH, "rb");
+	s_str.file = NativeAssets_OpenBigfile("rb");
 	if (s_str.file == NULL)
 	{
 		return 0;
 	}
 
-	s_str.baseOffset = (u32)bigfileSector * NATIVE_STR_EXTRACTED_SECTOR_SIZE;
-	if (fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET) != 0)
+	s_str.fileBaseOffset = (u32)bigfileSector * NATIVE_STR_EXTRACTED_SECTOR_SIZE;
+	if (NativeSTR_RewindFrameSource() == 0)
 	{
 		NativeSTR_Stop();
 		return 0;
@@ -711,7 +673,7 @@ s32 NativeSTR_StartScrapbook(void)
 	s_str.bigfileSector = -1;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = NATIVE_STR_SCRAPBOOK_FRAME_COUNT;
-	s_str.baseOffset = 0;
+	s_str.fileBaseOffset = 0;
 	return 1;
 }
 
@@ -727,6 +689,7 @@ void NativeSTR_Stop(void)
 	s_str.format = NATIVE_STR_FORMAT_EXTRACTED;
 	s_str.loop = 0;
 	s_str.bigfileSector = -1;
+	s_str.fileBaseOffset = 0;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = 0;
 	s_str.width = 0;

--- a/platform/native_str.c
+++ b/platform/native_str.c
@@ -44,7 +44,7 @@ struct NativeSTRState
 	s32 active;
 	s32 format;
 	s32 loop;
-	s32 bigfileIndex;
+	s32 bigfileSector;
 	u32 baseOffset;
 	s32 frameIndex;
 	s32 frameLimit;
@@ -661,7 +661,7 @@ internal s32 NativeSTR_ResolveBigfilePath(s32 bigfileIndex, char *dst, s32 dstCo
 
 s32 NativeSTR_StartTrackPreview(s32 bigfileSector, s32 frameCount)
 {
-	if ((s_str.active != 0) && (s_str.bigfileIndex == bigfileSector))
+	if ((s_str.active != 0) && (s_str.bigfileSector == bigfileSector))
 	{
 		return 1;
 	}
@@ -684,7 +684,7 @@ s32 NativeSTR_StartTrackPreview(s32 bigfileSector, s32 frameCount)
 	s_str.active = 1;
 	s_str.format = NATIVE_STR_FORMAT_EXTRACTED;
 	s_str.loop = 1;
-	s_str.bigfileIndex = bigfileSector;
+	s_str.bigfileSector = bigfileSector;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = frameCount;
 	return 1;
@@ -708,7 +708,7 @@ s32 NativeSTR_StartScrapbook(void)
 	s_str.active = 1;
 	s_str.format = NATIVE_STR_FORMAT_CD_STREAM;
 	s_str.loop = 0;
-	s_str.bigfileIndex = -1;
+	s_str.bigfileSector = -1;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = NATIVE_STR_SCRAPBOOK_FRAME_COUNT;
 	s_str.baseOffset = 0;
@@ -726,7 +726,7 @@ void NativeSTR_Stop(void)
 	s_str.active = 0;
 	s_str.format = NATIVE_STR_FORMAT_EXTRACTED;
 	s_str.loop = 0;
-	s_str.bigfileIndex = -1;
+	s_str.bigfileSector = -1;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = 0;
 	s_str.width = 0;

--- a/platform/native_str.c
+++ b/platform/native_str.c
@@ -4,6 +4,7 @@
 #include <platform/native_str.h>
 #include <psx/libgpu.h>
 
+
 #include <stdio.h>
 #include <string.h>
 
@@ -33,6 +34,10 @@ enum NativeSTRFormat
 	NATIVE_STR_FORMAT_CD_STREAM,
 };
 
+//read str track preview files from bigfile.big directly like retail
+//ideally i think we should use native_assets.c macro or something more global -penta3
+#define NATIVE_STR_BIGFILE_PATH             "BIGFILE.BIG"
+
 struct NativeSTRState
 {
 	FILE *file;
@@ -40,6 +45,7 @@ struct NativeSTRState
 	s32 format;
 	s32 loop;
 	s32 bigfileIndex;
+	u32 baseOffset;
 	s32 frameIndex;
 	s32 frameLimit;
 	s32 frameSize;
@@ -579,7 +585,7 @@ internal s32 NativeSTR_ReadNextFrame(void)
 				return 0;
 			}
 
-			rewind(s_str.file);
+			fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET);
 			s_str.frameIndex = 0;
 		}
 
@@ -594,13 +600,16 @@ internal s32 NativeSTR_ReadNextFrame(void)
 			return 0;
 		}
 
-		rewind(s_str.file);
+		fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET);
 		s_str.frameIndex = 0;
 	}
 
 	return 0;
 }
 
+/*
+//Retail does not need "bigfile.txt" to read track previews, it read throught bigfile.bigfile
+//keep this commented since is unused
 internal s32 NativeSTR_ResolveBigfilePath(s32 bigfileIndex, char *dst, s32 dstCount)
 {
 	FILE *file;
@@ -648,33 +657,34 @@ internal s32 NativeSTR_ResolveBigfilePath(s32 bigfileIndex, char *dst, s32 dstCo
 	fclose(file);
 	return 0;
 }
+*/
 
-s32 NativeSTR_StartTrackPreview(s32 bigfileIndex, s32 frameCount)
+s32 NativeSTR_StartTrackPreview(s32 bigfileSector, s32 frameCount)
 {
-	char path[NATIVE_STR_PATH_MAX];
-
-	if ((s_str.active != 0) && (s_str.bigfileIndex == bigfileIndex))
+	if ((s_str.active != 0) && (s_str.bigfileIndex == bigfileSector))
 	{
 		return 1;
 	}
 
 	NativeSTR_Stop();
 
-	if (NativeSTR_ResolveBigfilePath(bigfileIndex, path, sizeof(path)) == 0)
+	s_str.file = NativeAssets_Open(NATIVE_STR_BIGFILE_PATH, "rb");
+	if (s_str.file == NULL)
 	{
 		return 0;
 	}
 
-	s_str.file = fopen(path, "rb");
-	if (s_str.file == NULL)
+	s_str.baseOffset = (u32)bigfileSector * NATIVE_STR_EXTRACTED_SECTOR_SIZE;
+	if (fseek(s_str.file, (long)s_str.baseOffset, SEEK_SET) != 0)
 	{
+		NativeSTR_Stop();
 		return 0;
 	}
 
 	s_str.active = 1;
 	s_str.format = NATIVE_STR_FORMAT_EXTRACTED;
 	s_str.loop = 1;
-	s_str.bigfileIndex = bigfileIndex;
+	s_str.bigfileIndex = bigfileSector;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = frameCount;
 	return 1;
@@ -701,6 +711,7 @@ s32 NativeSTR_StartScrapbook(void)
 	s_str.bigfileIndex = -1;
 	s_str.frameIndex = 0;
 	s_str.frameLimit = NATIVE_STR_SCRAPBOOK_FRAME_COUNT;
+	s_str.baseOffset = 0;
 	return 1;
 }
 


### PR DESCRIPTION
the current implementation is assuming the user have the bigfile extracted as a folder and parsing bigfile.txt to find the bigfile index from the str files, in order to match retail i changed it to parse bigfile.big as it was intended for vanilla game, now track previews plays fine without extracting the bigfile