### PR TITLE
perf: console-faithful native layer, persistent VRAM without readbacks, exact NTSC pacing, bit-exact fast MDEC

### DIFF
--- a/platform/native_gpu_links.c
+++ b/platform/native_gpu_links.c
@@ -19,6 +19,12 @@ struct NativeGpuLinkRange
 global_variable struct NativeGpuLinkRange s_nativeGpuLinkRanges[NATIVE_GPU_LINK_MAX_RANGES];
 global_variable int s_nativeGpuLinkRangeCount;
 global_variable uint32_t s_nativeGpuLinkNextToken = NATIVE_GPU_LINK_FIRST_DYNAMIC_TOKEN;
+// NOTE(penta3): Last-hit cache. DrawOTag validates every linked node's pointer
+// through here, and consecutive OT nodes almost always live in the same arena, so
+// remembering the previous range turns the per-node linear scan into one compare
+// in the common case. Pure hint - falls back to the full scan, so behaviour is
+// unchanged. Index (not pointer) so it stays valid if the range array is reset.
+global_variable int s_lastHostRangeHit = 0;
 
 static int NativeGpuLinks_AlignTokenSize(size_t size, uint32_t *tokenSizeOut)
 {
@@ -43,6 +49,7 @@ void NativeGpuLinks_Reset(void)
 {
 	s_nativeGpuLinkRangeCount = 0;
 	s_nativeGpuLinkNextToken = NATIVE_GPU_LINK_FIRST_DYNAMIC_TOKEN;
+	s_lastHostRangeHit = 0;
 }
 
 int NativeGpuLinks_IsTerminator(uint32_t token)
@@ -107,11 +114,21 @@ void NativeGpuLinks_RegisterRangeChecked(const char *label, const void *hostStar
 
 static const struct NativeGpuLinkRange *NativeGpuLinks_FindHostRange(uintptr_t hostPtr)
 {
+	if (s_lastHostRangeHit < s_nativeGpuLinkRangeCount)
+	{
+		const struct NativeGpuLinkRange *cached = &s_nativeGpuLinkRanges[s_lastHostRangeHit];
+		if ((hostPtr >= cached->hostStart) && (hostPtr < cached->hostEnd))
+		{
+			return cached;
+		}
+	}
+
 	for (int i = 0; i < s_nativeGpuLinkRangeCount; i++)
 	{
 		const struct NativeGpuLinkRange *range = &s_nativeGpuLinkRanges[i];
 		if ((hostPtr >= range->hostStart) && (hostPtr < range->hostEnd))
 		{
+			s_lastHostRangeHit = i;
 			return range;
 		}
 	}

--- a/platform/native_libgpu.c
+++ b/platform/native_libgpu.c
@@ -44,7 +44,10 @@ int DrawSync(int mode)
 	{
 		DrawAllSplits();
 	}
-	NativeRenderer_ReadFramebufferDataToVRAM();
+	// NOTE(penta3): Real PS1 DrawSync only waits for the GPU; it never copies the
+	// framebuffer back into VRAM. We do the same: no per-frame readback here. The
+	// on-demand consumers that actually sample the framebuffer pull it when needed
+	// (StoreImage/ElimBG pause grab, MoveImage, save-state capture).
 
 	if (drawsync_callback != NULL)
 	{

--- a/platform/native_platform.c
+++ b/platform/native_platform.c
@@ -372,6 +372,8 @@ void Platform_EndScene(void)
 		return;
 	}
 
+	// NOTE(aalhendi): Keep the displayed VRAM region current for screen-copy
+	// effects without forcing a CPU readback.
 	NativeRenderer_StoreFrameBuffer(activeDispEnv.disp.x, activeDispEnv.disp.y, activeDispEnv.disp.w, activeDispEnv.disp.h);
 
 	NativeRenderer_SwapWindow();
@@ -529,12 +531,19 @@ int NikoGetEnterKey(void)
 	return (kb && kb[SDL_SCANCODE_RETURN]) ? 1 : 0;
 }
 
-// NOTE(aalhendi): Native owns the CTR VBlank clock instead of PsyCross's
-// autonomous interrupt thread. The retail-shaped VSyncCallback storage lives in
-// native_libetc.c; native VSync emits that callback at each emulated VBlank.
-#define NATIVE_VSYNC_HZ          60
+// NOTE(aalhendi): VSyncCallback uses the PSX facade, but native owns the VBlank
+// clock that emits the registered callback.
+// NOTE(aalhendi): Native paces VBlank from PS1 NTSC video timing instead of
+// rounded 60Hz. PSX-SPX lists NTSC as 263 scanlines/frame and about 3413 video
+// cycles/scanline. With the NTSC GPU clock used here, this is ~59.817Hz, making
+// VSync(2) roughly 29.909 FPS. This affects host wall pacing; game state still
+// advances from emitted VBlank counts and retail RCNT1 ticks.
+#define NATIVE_VBLANK_GPU_CYCLES 897619ull // 3413 * 263
+#define NATIVE_GPU_CLOCK_HZ      53693175ull
 #define NATIVE_VSYNC_CATCHUP_MAX 8
-#define NATIVE_VSYNC_SPIN_US     1000
+// NOTE(aalhendi): SDL_DelayPrecise handles most of the wait; the final window
+// spins against SDL's performance counter so pacing follows the VBlank target.
+#define NATIVE_VSYNC_SPIN_US     200
 
 global_variable u64 s_nextVBlankCounter = 0;
 global_variable u64 s_vblankRemainder = 0;
@@ -548,14 +557,16 @@ internal u64 Native_CounterFromMicroseconds(u64 freq, u64 microseconds)
 internal void Native_AdvanceVBlankTarget(void)
 {
 	const u64 freq = SDL_GetPerformanceFrequency();
-	const u64 hz = NATIVE_VSYNC_HZ;
+	// counter ticks per vblank = freq * (897619 / 53693175) sec, kept exact with a
+	// running remainder. freq*897619 fits u64 for any realistic QPC frequency.
+	const u64 numer = freq * NATIVE_VBLANK_GPU_CYCLES;
 
-	s_nextVBlankCounter += freq / hz;
-	s_vblankRemainder += freq % hz;
-	if (s_vblankRemainder >= hz)
+	s_nextVBlankCounter += numer / NATIVE_GPU_CLOCK_HZ;
+	s_vblankRemainder += numer % NATIVE_GPU_CLOCK_HZ;
+	if (s_vblankRemainder >= NATIVE_GPU_CLOCK_HZ)
 	{
 		s_nextVBlankCounter++;
-		s_vblankRemainder -= hz;
+		s_vblankRemainder -= NATIVE_GPU_CLOCK_HZ;
 	}
 }
 
@@ -581,7 +592,7 @@ internal void Native_WaitUntilVBlankTarget(void)
 	{
 		const u64 now = SDL_GetPerformanceCounter();
 		u64 remaining;
-		u64 sleepMs;
+		u64 sleepUs;
 
 		if (now >= s_nextVBlankCounter)
 		{
@@ -592,9 +603,10 @@ internal void Native_WaitUntilVBlankTarget(void)
 		remaining = s_nextVBlankCounter - now;
 		if (remaining <= spinWindow)
 		{
-			// NOTE(aalhendi): SDL_Delay can wake late. Sleep while safely far
-			// from the VBlank target, then spin the final small window so the
-			// native VBlank emitter is paced by our clock, not the OS scheduler.
+			// NOTE(penta3): OS sleeps can wake late. Sleep while safely far from
+			// the VBlank target (high-res waitable timer), then spin only this
+			// final small window so the native VBlank emitter is paced by our
+			// clock, not the OS scheduler.
 			while (SDL_GetPerformanceCounter() < s_nextVBlankCounter)
 			{
 			}
@@ -603,10 +615,15 @@ internal void Native_WaitUntilVBlankTarget(void)
 			return;
 		}
 
-		sleepMs = ((remaining - spinWindow) * 1000) / freq;
-		if (sleepMs > 0)
+		sleepUs = ((remaining - spinWindow) * 1000000) / freq;
+		if (sleepUs > 0)
 		{
-			SDL_Delay((u32)sleepMs);
+			// Cross-platform precise sleep: SDL_DelayPrecise uses the best per-OS
+			// primitive (Win32 high-res waitable timer, Linux clock_nanosleep) and
+			// yields the CPU instead of busy-waiting. Waking slightly late is safe:
+			// the vblank schedule is absolute, so no drift accumulates and the loop
+			// re-checks against the target.
+			SDL_DelayPrecise(sleepUs * 1000ull);
 		}
 	}
 }
@@ -630,6 +647,29 @@ internal int Native_CatchUpDueVBlanks(void)
 
 	Native_EnsureVBlankTarget();
 
+	// NOTE(aalhendi): Native host stalls can be much longer than retail frame
+	// stalls, for example during window dragging or a debugger break. Replay a few
+	// late VBlanks normally, but rebase pathological stalls instead of bursting
+	// many callbacks into one host frame.
+	{
+		const u64 now = SDL_GetPerformanceCounter();
+
+		if (now >= s_nextVBlankCounter)
+		{
+			const u64 freq = SDL_GetPerformanceFrequency();
+			const u64 step = (freq * NATIVE_VBLANK_GPU_CYCLES) / NATIVE_GPU_CLOCK_HZ;
+			const u64 dueApprox = ((now - s_nextVBlankCounter) / step) + 1;
+
+			if (dueApprox > NATIVE_VSYNC_CATCHUP_MAX)
+			{
+				s_nextVBlankCounter = now;
+				s_vblankRemainder = 0;
+				Native_AdvanceVBlankTarget();
+				return 0;
+			}
+		}
+	}
+
 	while (SDL_GetPerformanceCounter() >= s_nextVBlankCounter)
 	{
 		const u64 now = SDL_GetPerformanceCounter();
@@ -639,9 +679,8 @@ internal int Native_CatchUpDueVBlanks(void)
 
 		if (emittedVBlanks >= NATIVE_VSYNC_CATCHUP_MAX)
 		{
-			// NOTE(aalhendi): Debugger stalls can otherwise replay minutes of
-			// VBlank callbacks at once. Keep normal late frames faithful, but
-			// rebase pathological host pauses.
+			// NOTE(aalhendi): Keep normal late frames faithful, but rebase if the
+			// due count grew past the cap while we were replaying.
 			s_nextVBlankCounter = now;
 			s_vblankRemainder = 0;
 			Native_AdvanceVBlankTarget();

--- a/platform/native_renderer.c
+++ b/platform/native_renderer.c
@@ -27,7 +27,12 @@ __declspec(dllexport) int AmdPowerXpressRequestHighPerformance = 1;
 #endif // def WIN32
 
 #define VRAM_FORMAT          GL_RG
-#define VRAM_INTERNAL_FORMAT GL_RG32F
+// NOTE(penta3): VRAM holds packed 16-bit PSX pixels as two bytes (R=low,
+// G=high), uploaded as GL_RG + GL_UNSIGNED_BYTE. RG8 is the faithful storage:
+// 2 bytes/texel = real PS1's 1MB VRAM, vs RG32F's 8 bytes/texel (4MB). With
+// NEAREST sampling RG8 returns byte/255 exactly, identical to what the shader
+// got from RG32F, so CLUT/texture-page reconstruction is unchanged.
+#define VRAM_INTERNAL_FORMAT GL_RG8
 
 extern SDL_Window *g_window;
 
@@ -47,10 +52,14 @@ global_variable RECT16 s_previousOffscreen = {0, 0, 0, 0};
 
 global_variable ShaderID s_previousShader = (ShaderID)-1;
 
-global_variable TextureID s_vramTexturesDouble[2];
 global_variable TextureID s_vramTexture;
 global_variable TextureID s_rgLutTexture = (TextureID)-1;
-global_variable int s_vramTextureIndex = 0;
+// NOTE(penta3): Single persistent VRAM texture, matching real PS1's single
+// 1MB VRAM. PS1 page-flips two windows *inside* one VRAM; it never keeps two
+// full copies. The old double buffer existed only to orphan the texture on the
+// per-frame full re-upload, which no longer happens (we upload dirty rects).
+global_variable u32 *s_readbackScratch = NULL;
+global_variable size_t s_readbackScratchPixels = 0;
 
 global_variable TextureID s_framebufferTexture = (TextureID)-1;
 global_variable TextureID s_offscreenRenderTexture = (TextureID)-1;
@@ -80,7 +89,23 @@ int g_dbg_texturelessMode = 0;
 
 int g_cfg_bilinearFiltering = 0;
 
+// NOTE(penta3): GPU-side framebuffer pack pipeline (see NativeRenderer_StoreFrameBuffer).
+// Packs the RGBA framebuffer texture into the RG8 VRAM texture on the GPU instead of a
+// GPU->CPU readback + CPU pack + re-upload.
+global_variable GLuint s_packShader = 0;
+global_variable GLint s_packSrcLoc = -1;
+global_variable GLuint s_packQuadVAO = 0;
+global_variable GLuint s_packQuadVBO = 0;
+
+#define NATIVE_VRAM_DIRTY_RECT_CAP 128
+
 global_variable int s_vramNeedsUpdate = 1;
+// NOTE(aalhendi): PS1 VRAM is one persistent memory. Native mirrors CPU writes
+// as exact dirty rectangles so unrelated stale CPU pixels never overwrite newer
+// GPU-authored VRAM during the next GL upload.
+global_variable RECT16 s_vramDirtyRects[NATIVE_VRAM_DIRTY_RECT_CAP] = {{0, 0, VRAM_WIDTH, VRAM_HEIGHT}};
+global_variable int s_vramDirtyRectCount = 1;
+global_variable int s_cpuVRAMMirrorStale = 0;
 global_variable int s_framebufferNeedsUpdate = 0;
 
 internal int NativeRenderer_InitialiseGLContext(char *windowName, int fullscreen);
@@ -210,13 +235,20 @@ void NativeRenderer_Shutdown(void)
 	glDeleteFramebuffers(1, &s_glOffscreenFramebuffer);
 	glDeleteFramebuffers(1, &s_glVramFramebuffer);
 
-	NativeRenderer_DestroyTexture(s_vramTexturesDouble[0]);
-	NativeRenderer_DestroyTexture(s_vramTexturesDouble[1]);
+	NativeRenderer_DestroyTexture(s_vramTexture);
 
 	NativeRenderer_DestroyTexture(s_whiteTexture);
 	NativeRenderer_DestroyTexture(s_rgLutTexture);
 	NativeRenderer_DestroyTexture(s_framebufferTexture);
 	NativeRenderer_DestroyTexture(s_offscreenRenderTexture);
+
+	free(s_readbackScratch);
+	s_readbackScratch = NULL;
+	s_readbackScratchPixels = 0;
+
+	glDeleteProgram(s_packShader);
+	glDeleteVertexArrays(1, &s_packQuadVAO);
+	glDeleteBuffers(1, &s_packQuadVBO);
 }
 
 void NativeRenderer_UpdateSwapIntervalState(int swapInterval)
@@ -420,6 +452,7 @@ internal void NativeRenderer_InitRG8LUT(void);
 internal void NativeRenderer_Ortho2D(float left, float right, float bottom, float top, float znear, float zfar);
 internal void NativeRenderer_SetShader(const ShaderID shader);
 internal void NativeRenderer_CopyRGBAFramebufferToVRAM(u32 *src, int x, int y, int w, int h, int update_vram, int flip_y);
+internal void NativeRenderer_SyncGpuVRAMToCPU(void);
 
 global_variable GTEShader s_gteShader4;
 global_variable GTEShader s_gteShader8;
@@ -805,6 +838,49 @@ internal void NativeRenderer_InitialisePSXShaders(void)
 	NativeRenderer_CompilePSXShader(&s_gteShader32Rgba, gte_shader_32_rgba);
 }
 
+// NOTE(penta3): GPU framebuffer pack. Samples the RGBA framebuffer texture and
+// writes 16-bit PS1 pixels (r5|g5<<5|b5<<10|stp<<15) into the RG8 VRAM texture,
+// low byte in R and high byte in G - the exact layout CopyRGBAFramebufferToVRAM
+// produces on the CPU. Integer ops keep it bit-exact; NEAREST sampling returns the
+// stored byte so `*255+0.5` recovers it without rounding drift.
+global_variable const char *ctr_pack_shader = "#ifdef VERTEX\n"
+                                              "attribute vec2 a_position;\n"
+                                              "varying vec2 v_uv;\n"
+                                              "void main() {\n"
+                                              "	v_uv = a_position * 0.5 + 0.5;\n"
+                                              "	gl_Position = vec4(a_position, 0.0, 1.0);\n"
+                                              "}\n"
+                                              "#endif\n"
+                                              "#ifdef FRAGMENT\n"
+                                              "varying vec2 v_uv;\n"
+                                              "uniform sampler2D s_src;\n"
+                                              "void main() {\n"
+                                              "	ivec4 c = ivec4(texture2D(s_src, v_uv) * 255.0 + 0.5);\n"
+                                              "	int px16 = (c.r >> 3) | ((c.g >> 3) << 5) | ((c.b >> 3) << 10) | ((c.a >> 7) << 15);\n"
+                                              "	fragColor = vec4(float(px16 & 0xFF) / 255.0, float((px16 >> 8) & 0xFF) / 255.0, 0.0, 0.0);\n"
+                                              "}\n"
+                                              "#endif\n";
+
+internal void NativeRenderer_InitPackPipeline(void)
+{
+	local_persist const float quad[12] = {-1.f, -1.f, -1.f, 1.f, 1.f, 1.f, -1.f, -1.f, 1.f, 1.f, 1.f, -1.f};
+
+	s_packShader = NativeRenderer_Shader_Compile(ctr_pack_shader, false);
+	glUseProgram(s_packShader);
+	s_packSrcLoc = glGetUniformLocation(s_packShader, "s_src");
+	glUniform1i(s_packSrcLoc, 0);
+	glUseProgram(0);
+
+	glGenVertexArrays(1, &s_packQuadVAO);
+	glGenBuffers(1, &s_packQuadVBO);
+	glBindVertexArray(s_packQuadVAO);
+	glBindBuffer(GL_ARRAY_BUFFER, s_packQuadVBO);
+	glBufferData(GL_ARRAY_BUFFER, sizeof(quad), quad, GL_STATIC_DRAW);
+	glEnableVertexAttribArray(a_position);
+	glVertexAttribPointer(a_position, 2, GL_FLOAT, GL_FALSE, 2 * sizeof(float), (void *)0);
+	glBindVertexArray(0);
+}
+
 internal void NativeRenderer_InitRG8LUT(void)
 {
 	for (u16 y = 0; y < LUT_HEIGHT; y++)
@@ -828,6 +904,7 @@ int NativeRenderer_InitialisePSX(void)
 	NativeRenderer_InitRG8LUT();
 	NativeRenderer_GenerateCommonTextures();
 	NativeRenderer_InitialisePSXShaders();
+	NativeRenderer_InitPackPipeline();
 
 	glDepthFunc(GL_LEQUAL);
 	glEnable(GL_STENCIL_TEST);
@@ -890,25 +967,17 @@ int NativeRenderer_InitialisePSX(void)
 		}
 	}
 
-	// gen VRAM textures.
-	// double-buffered
+	// gen VRAM texture (single, persistent - mirrors PS1's single 1MB VRAM)
 	{
-		int i;
+		glGenTextures(1, &s_vramTexture);
 
-		glGenTextures(2, s_vramTexturesDouble);
+		glBindTexture(GL_TEXTURE_2D, s_vramTexture);
 
-		for (i = 0; i < 2; i++)
-		{
-			glBindTexture(GL_TEXTURE_2D, s_vramTexturesDouble[i]);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
 
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-			glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-			// set storage size
-			glTexImage2D(GL_TEXTURE_2D, 0, VRAM_INTERNAL_FORMAT, VRAM_WIDTH, VRAM_HEIGHT, 0, VRAM_FORMAT, GL_UNSIGNED_BYTE, NULL);
-		}
-
-		s_vramTexture = s_vramTexturesDouble[0];
+		// set storage size
+		glTexImage2D(GL_TEXTURE_2D, 0, VRAM_INTERNAL_FORMAT, VRAM_WIDTH, VRAM_HEIGHT, 0, VRAM_FORMAT, GL_UNSIGNED_BYTE, NULL);
 
 		glBindTexture(GL_TEXTURE_2D, 0);
 
@@ -1044,17 +1113,12 @@ internal void NativeRenderer_SetShader(const ShaderID shader)
 
 void NativeRenderer_SetTexture(TextureID texture, TexFormat texFormat)
 {
-	GLint texLoc = -1;
-	GLint lutLoc = -1;
-
 	switch (texFormat)
 	{
 	case TF_4_BIT:
 		NativeRenderer_SetShader(s_gteShader4.shader);
 		u_bilinearFilterLoc = s_gteShader4.bilinearFilterLoc;
 		u_projectionLoc = s_gteShader4.projectionLoc;
-		texLoc = s_gteShader4.texLoc;
-		lutLoc = s_gteShader4.lutLoc;
 		u_texelSizeLoc = -1;
 		u_psxSemiTransPassLoc = s_gteShader4.psxSemiTransPassLoc;
 		u_psxDrawMaskSetLoc = s_gteShader4.psxDrawMaskSetLoc;
@@ -1064,8 +1128,6 @@ void NativeRenderer_SetTexture(TextureID texture, TexFormat texFormat)
 		NativeRenderer_SetShader(s_gteShader8.shader);
 		u_bilinearFilterLoc = s_gteShader8.bilinearFilterLoc;
 		u_projectionLoc = s_gteShader8.projectionLoc;
-		texLoc = s_gteShader8.texLoc;
-		lutLoc = s_gteShader8.lutLoc;
 		u_texelSizeLoc = -1;
 		u_psxSemiTransPassLoc = s_gteShader8.psxSemiTransPassLoc;
 		u_psxDrawMaskSetLoc = s_gteShader8.psxDrawMaskSetLoc;
@@ -1075,8 +1137,6 @@ void NativeRenderer_SetTexture(TextureID texture, TexFormat texFormat)
 		NativeRenderer_SetShader(s_gteShader16.shader);
 		u_bilinearFilterLoc = s_gteShader16.bilinearFilterLoc;
 		u_projectionLoc = s_gteShader16.projectionLoc;
-		texLoc = s_gteShader16.texLoc;
-		lutLoc = s_gteShader16.lutLoc;
 		u_texelSizeLoc = -1;
 		u_psxSemiTransPassLoc = s_gteShader16.psxSemiTransPassLoc;
 		u_psxDrawMaskSetLoc = s_gteShader16.psxDrawMaskSetLoc;
@@ -1086,8 +1146,6 @@ void NativeRenderer_SetTexture(TextureID texture, TexFormat texFormat)
 		NativeRenderer_SetShader(s_gteShader32Rgba.shader);
 		u_bilinearFilterLoc = s_gteShader32Rgba.bilinearFilterLoc;
 		u_projectionLoc = s_gteShader32Rgba.projectionLoc;
-		texLoc = s_gteShader32Rgba.texLoc;
-		lutLoc = s_gteShader32Rgba.lutLoc;
 		u_texelSizeLoc = s_gteShader32Rgba.texelSizeLoc;
 		u_psxSemiTransPassLoc = s_gteShader32Rgba.psxSemiTransPassLoc;
 		u_psxDrawMaskSetLoc = s_gteShader32Rgba.psxDrawMaskSetLoc;
@@ -1100,14 +1158,10 @@ void NativeRenderer_SetTexture(TextureID texture, TexFormat texFormat)
 		texture = s_whiteTexture;
 	}
 
-	if (texLoc >= 0)
-	{
-		glUniform1i(texLoc, 0);
-	}
-	if (lutLoc >= 0)
-	{
-		glUniform1i(lutLoc, 1);
-	}
+	// NOTE(penta3): s_texture (unit 0) and s_rgLut (unit 1) sampler bindings are baked
+	// into each program at compile time (NativeRenderer_Shader_Compile) and uniform
+	// values persist per-program, so re-setting them on every split was redundant GL
+	// churn. bilinearFilter stays here because it toggles at runtime (debug key).
 	if (u_bilinearFilterLoc >= 0)
 	{
 		glUniform1i(u_bilinearFilterLoc, g_cfg_bilinearFiltering);
@@ -1186,10 +1240,129 @@ internal float NativeRenderer_PSXColorComponentFloat(u8 value)
 	return (float)psx8 / 255.0f;
 }
 
+internal int NativeRenderer_ClipVRAMRect(RECT16 *out, int x, int y, int w, int h)
+{
+	if ((w <= 0) || (h <= 0))
+	{
+		return 0;
+	}
+
+	if (x < 0)
+	{
+		w += x;
+		x = 0;
+	}
+	if (y < 0)
+	{
+		h += y;
+		y = 0;
+	}
+	if (x + w > VRAM_WIDTH)
+	{
+		w = VRAM_WIDTH - x;
+	}
+	if (y + h > VRAM_HEIGHT)
+	{
+		h = VRAM_HEIGHT - y;
+	}
+	if ((w <= 0) || (h <= 0))
+	{
+		return 0;
+	}
+
+	out->x = (s16)x;
+	out->y = (s16)y;
+	out->w = (s16)w;
+	out->h = (s16)h;
+	return 1;
+}
+
+internal int NativeRenderer_DirtyRectContains(const RECT16 *outer, const RECT16 *inner)
+{
+	const int outerRight = outer->x + outer->w;
+	const int outerBottom = outer->y + outer->h;
+	const int innerRight = inner->x + inner->w;
+	const int innerBottom = inner->y + inner->h;
+
+	return (outer->x <= inner->x) && (outer->y <= inner->y) && (outerRight >= innerRight) && (outerBottom >= innerBottom);
+}
+
+internal int NativeRenderer_TryMergeDirtyRect(RECT16 *dst, const RECT16 *src)
+{
+	const int dstRight = dst->x + dst->w;
+	const int dstBottom = dst->y + dst->h;
+	const int srcRight = src->x + src->w;
+	const int srcBottom = src->y + src->h;
+
+	if ((dst->y == src->y) && (dst->h == src->h) && (src->x <= dstRight) && (dst->x <= srcRight))
+	{
+		const int x0 = (src->x < dst->x) ? src->x : dst->x;
+		const int x1 = (srcRight > dstRight) ? srcRight : dstRight;
+		dst->x = (s16)x0;
+		dst->w = (s16)(x1 - x0);
+		return 1;
+	}
+
+	if ((dst->x == src->x) && (dst->w == src->w) && (src->y <= dstBottom) && (dst->y <= srcBottom))
+	{
+		const int y0 = (src->y < dst->y) ? src->y : dst->y;
+		const int y1 = (srcBottom > dstBottom) ? srcBottom : dstBottom;
+		dst->y = (s16)y0;
+		dst->h = (s16)(y1 - y0);
+		return 1;
+	}
+
+	return 0;
+}
+
+internal void NativeRenderer_AppendVRAMDirtyRect(const RECT16 *rect)
+{
+	for (int i = 0; i < s_vramDirtyRectCount; i++)
+	{
+		if (NativeRenderer_DirtyRectContains(&s_vramDirtyRects[i], rect))
+		{
+			return;
+		}
+
+		if (NativeRenderer_DirtyRectContains(rect, &s_vramDirtyRects[i]))
+		{
+			s_vramDirtyRects[i] = *rect;
+			return;
+		}
+
+		if (NativeRenderer_TryMergeDirtyRect(&s_vramDirtyRects[i], rect))
+		{
+			return;
+		}
+	}
+
+	if (s_vramDirtyRectCount >= NATIVE_VRAM_DIRTY_RECT_CAP)
+	{
+		NativeRenderer_UpdateVRAM();
+	}
+
+	if (s_vramDirtyRectCount < NATIVE_VRAM_DIRTY_RECT_CAP)
+	{
+		s_vramDirtyRects[s_vramDirtyRectCount] = *rect;
+		s_vramDirtyRectCount++;
+	}
+}
+
+internal void NativeRenderer_MarkVRAMDirty(int x, int y, int w, int h)
+{
+	RECT16 rect;
+
+	if (!NativeRenderer_ClipVRAMRect(&rect, x, y, w, h))
+	{
+		return;
+	}
+
+	NativeRenderer_AppendVRAMDirtyRect(&rect);
+	s_vramNeedsUpdate = 1;
+}
+
 void NativeRenderer_ClearVRAM(int x, int y, int w, int h, u8 r, u8 g, u8 b)
 {
-	s_vramNeedsUpdate = 1;
-
 	u16 *dst = vram + x + y * VRAM_WIDTH;
 	const u16 color = NativeRenderer_PackRGB24ToPSX15(r, g, b);
 
@@ -1215,6 +1388,8 @@ void NativeRenderer_ClearVRAM(int x, int y, int w, int h, u8 r, u8 g, u8 b)
 
 		dst += VRAM_WIDTH;
 	}
+
+	NativeRenderer_MarkVRAMDirty(x, y, w, h);
 }
 
 void NativeRenderer_Clear(int x, int y, int w, int h, u8 r, u8 g, u8 b)
@@ -1306,6 +1481,8 @@ void NativeRenderer_SaveVRAM(const char *outputFileName, int x, int y, int width
 	(void)y;
 	(void)bReadFromFrameBuffer;
 
+	NativeRenderer_ReadFramebufferDataToVRAM();
+
 	FILE *fp = fopen(outputFileName, "wb");
 	if (fp == NULL)
 	{
@@ -1341,15 +1518,20 @@ internal void NativeRenderer_CopyRGBAFramebufferToVRAM(u32 *src, int x, int y, i
 	assert(x + w <= VRAM_WIDTH);
 	assert(y + h <= VRAM_HEIGHT);
 
-	u16 *fb = (u16 *)malloc(w * h * sizeof(u16));
-	u32 *data_src = (u32 *)src;
-	u16 *data_dst = (u16 *)fb;
-
-	for (int i = 0; i < h; i++)
+	// NOTE(penta3): Pack the RGBA readback into 15-bit+STP straight into the CPU
+	// VRAM mirror. VRAM row fy takes source row (flip_y ? h-1-fy : fy), so the flip
+	// lives on the source index and the destination walks VRAM linearly. This drops
+	// the old full-frame pack scratch and the identity-indexed second copy (both ran
+	// on every readback via DrawSync) for a bit-identical result.
+	for (int fy = 0; fy < h; fy++)
 	{
-		for (int j = 0; j < w; j++)
+		const int srcRow = flip_y ? (h - fy - 1) : fy;
+		const u32 *s = src + (size_t)srcRow * w;
+		u16 *dst = vram + (size_t)(y + fy) * VRAM_WIDTH + x;
+
+		for (int fx = 0; fx < w; fx++)
 		{
-			u32 c = *data_src++;
+			u32 c = s[fx];
 
 			u8 r = ((c >> 3) & 0x1F);
 			u8 g = ((c >> 11) & 0x1F);
@@ -1357,36 +1539,70 @@ internal void NativeRenderer_CopyRGBAFramebufferToVRAM(u32 *src, int x, int y, i
 			// NOTE(aalhendi): framebuffer alpha carries the PS1 E6 mask/STP bit.
 			u8 a = (c >> 31) & 1;
 
-			*data_dst++ = r | (g << 5) | (b << 10) | (a << 15);
+			dst[fx] = r | (g << 5) | (b << 10) | (a << 15);
 		}
 	}
-
-	u16 *ptr = (u16 *)vram + VRAM_WIDTH * y + x;
-
-	for (int fy = 0; fy < h; fy++)
-	{
-		int py = flip_y ? (h - fy - 1) : fy;
-		u16 *fb_ptr = fb + (h * py / h) * w;
-
-		for (int fx = 0; fx < w; fx++)
-		{
-			ptr[fx] = fb_ptr[w * fx / w];
-		}
-
-		ptr += VRAM_WIDTH;
-	}
-
-	free(fb);
 
 	if (update_vram)
 	{
-		s_vramNeedsUpdate = 1;
+		NativeRenderer_MarkVRAMDirty(x, y, w, h);
 	}
+}
+
+// NOTE(penta3): Shared persistent scratch for GPU->CPU readbacks. Grows on demand to
+// the largest region actually read back (`pixels` = w*h RGBA texels), settling at the
+// real high-water mark instead of pre-reserving a full 2MB VRAM frame. Only reallocs
+// when a bigger readback appears, so hot paths still don't malloc/free per call. The
+// readback paths are never nested, so a single buffer is safe.
+internal u32 *NativeRenderer_GetReadbackScratch(int pixels)
+{
+	if ((size_t)pixels > s_readbackScratchPixels)
+	{
+		u32 *grown = (u32 *)realloc(s_readbackScratch, (size_t)pixels * sizeof(u32));
+		if (grown == NULL)
+		{
+			return NULL;
+		}
+		s_readbackScratch = grown;
+		s_readbackScratchPixels = (size_t)pixels;
+	}
+
+	return s_readbackScratch;
+}
+
+internal void NativeRenderer_SyncGpuVRAMToCPU(void)
+{
+	if (!s_cpuVRAMMirrorStale)
+	{
+		return;
+	}
+
+	// NOTE(aalhendi): CPU writes must land in the persistent GL VRAM texture
+	// before the CPU mirror is refreshed from it. This preserves PS1 command
+	// ordering while avoiding the old per-frame framebuffer readback.
+	NativeRenderer_UpdateVRAM();
+
+	NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_READBACK);
+	glBindTexture(GL_TEXTURE_2D, s_vramTexture);
+	glGetTexImage(GL_TEXTURE_2D, 0, VRAM_FORMAT, GL_UNSIGNED_BYTE, vram);
+	glBindTexture(GL_TEXTURE_2D, 0);
+	NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_READBACK);
+
+	s_cpuVRAMMirrorStale = 0;
+	s_framebufferNeedsUpdate = 0;
+	s_lastBoundTexture = (TextureID)-1;
 }
 
 void NativeRenderer_ReadFramebufferDataToVRAM(void)
 {
 	int x, y, w, h;
+	u32 *pixels;
+	if (s_cpuVRAMMirrorStale)
+	{
+		NativeRenderer_SyncGpuVRAMToCPU();
+		return;
+	}
+
 	if (!s_framebufferNeedsUpdate)
 	{
 		return;
@@ -1404,7 +1620,7 @@ void NativeRenderer_ReadFramebufferDataToVRAM(void)
 		return;
 	}
 
-	u32 *pixels = (u32 *)malloc((size_t)w * (size_t)h * sizeof(u32));
+	pixels = NativeRenderer_GetReadbackScratch(w * h);
 	if (pixels != NULL)
 	{
 		glBindTexture(GL_TEXTURE_2D, s_framebufferTexture);
@@ -1418,8 +1634,6 @@ void NativeRenderer_ReadFramebufferDataToVRAM(void)
 		// Host texture bindings are invalid after this direct GL texture read.
 		NativeRenderer_CopyRGBAFramebufferToVRAM(pixels, x, y, w, h, 1, 0);
 		s_lastBoundTexture = (TextureID)-1;
-
-		free(pixels);
 	}
 }
 
@@ -1459,7 +1673,7 @@ internal void NativeRenderer_FlushOffscreenToVRAM(void)
 
 	// copy rendering results to the CPU-side PSX VRAM mirror
 	{
-		u32 *pixels = (u32 *)malloc((size_t)s_previousOffscreen.w * (size_t)s_previousOffscreen.h * sizeof(u32));
+		u32 *pixels = NativeRenderer_GetReadbackScratch(s_previousOffscreen.w * s_previousOffscreen.h);
 		if (pixels == NULL)
 		{
 			return;
@@ -1470,7 +1684,6 @@ internal void NativeRenderer_FlushOffscreenToVRAM(void)
 		glBindTexture(GL_TEXTURE_2D, s_lastBoundTexture != (TextureID)-1 ? s_lastBoundTexture : 0);
 
 		NativeRenderer_CopyRGBAFramebufferToVRAM(pixels, s_previousOffscreen.x, s_previousOffscreen.y, s_previousOffscreen.w, s_previousOffscreen.h, 0, 1);
-		free(pixels);
 	}
 }
 
@@ -1554,9 +1767,9 @@ void NativeRenderer_SetOffscreenState(const RECT16 *offscreenRect, const DISPENV
 	}
 }
 
-void NativeRenderer_StoreFrameBuffer(int x, int y, int w, int h)
+// Blit the presented backbuffer into the framebuffer texture (GPU->GPU only).
+internal void NativeRenderer_BlitBackbufferToFramebufferTex(int x, int y, int w, int h)
 {
-	NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_STORE);
 	// set storage size first
 	if (s_previousFramebuffer.w != w || s_previousFramebuffer.h != h)
 	{
@@ -1581,8 +1794,17 @@ void NativeRenderer_StoreFrameBuffer(int x, int y, int w, int h)
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0); // source is backbuffer
 		glBindFramebuffer(GL_DRAW_FRAMEBUFFER, s_glBlitFramebuffer);
 
-		glBlitFramebuffer(s_presentViewport.x, s_presentViewport.y, s_presentViewport.x + s_presentViewport.w, s_presentViewport.y + s_presentViewport.h, x,
-		                  y + h, x + w, y, GL_COLOR_BUFFER_BIT, GL_NEAREST);
+		// NOTE(penta3): The framebuffer texture is a REGION snapshot sized w*h; every
+		// consumer (GPU pack shader, glGetTexImage readbacks) reads it from 0,0 and
+		// re-places it at the VRAM (x,y) themselves, so the blit destination must be
+		// region-relative. The old dst used the VRAM-absolute y: for the high buffer
+		// (y=0x128=296 -> rows 296..512 of a 216-row texture) GL clipped the ENTIRE
+		// blit and the texture silently kept the previous frame. Every other frame the
+		// feedback effects then sampled a 1-frame-old image: moving warp (warpball)
+		// doubled, heat ghosted overlapping UI, while static heat and the clock blur
+		// (previous-frame by design) masked it.
+		glBlitFramebuffer(s_presentViewport.x, s_presentViewport.y, s_presentViewport.x + s_presentViewport.w, s_presentViewport.y + s_presentViewport.h, 0, h,
+		                  w, 0, GL_COLOR_BUFFER_BIT, GL_NEAREST);
 
 		// done, unbind
 		glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
@@ -1590,53 +1812,67 @@ void NativeRenderer_StoreFrameBuffer(int x, int y, int w, int h)
 		NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_BLIT);
 	}
 
-	// after drawing
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
-	NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_FLUSH);
-	glFlush();
-	NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_FLUSH);
+}
 
-	NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_ALLOC);
-	u32 *pixels = (u32 *)malloc((size_t)w * (size_t)h * sizeof(u32));
-	NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_ALLOC);
-	if (pixels != NULL)
-	{
-		// NOTE(aalhendi): Screen-feedback effects sample PS1 VRAM as packed
-		// 16-bit pixels. Do not leave the VRAM texture in host RGBA form here;
-		// pack the copied framebuffer synchronously before the next primitive
-		// can sample it.
-		glBindTexture(GL_TEXTURE_2D, s_framebufferTexture);
-		NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_READBACK);
-		glGetTexImage(GL_TEXTURE_2D, 0, GL_RGBA, GL_UNSIGNED_BYTE, pixels);
-		NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_READBACK);
-		glBindTexture(GL_TEXTURE_2D, 0);
+// NOTE(penta3): Pack the RGBA framebuffer texture straight into the RG8 VRAM
+// texture on the GPU, no CPU round-trip. Writes the same (x,y,w,h) VRAM region the
+// CPU path targets. Restores/invalidates the render-state caches it disturbs so the
+// in-progress submit run keeps working.
+internal void NativeRenderer_GpuPackFramebufferToVRAM(int x, int y, int w, int h)
+{
+	glBindFramebuffer(GL_FRAMEBUFFER, s_glVramFramebuffer);
+	glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, s_vramTexture, 0);
 
-		NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_PACK);
-		NativeRenderer_CopyRGBAFramebufferToVRAM(pixels, x, y, w, h, 1, 0);
-		NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_PACK);
-		NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_VRAM_UPLOAD);
-		NativeRenderer_UpdateVRAM();
-		NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_VRAM_UPLOAD);
-		s_lastBoundTexture = -1;
+	glDisable(GL_BLEND);
+	glDisable(GL_SCISSOR_TEST);
+	glViewport(x, y, w, h);
 
-		free(pixels);
-	}
+	glUseProgram(s_packShader);
+	glActiveTexture(GL_TEXTURE0);
+	glBindTexture(GL_TEXTURE_2D, s_framebufferTexture);
+	glUniform1i(s_packSrcLoc, 0);
+
+	glBindVertexArray(s_packQuadVAO);
+	glDrawArrays(GL_TRIANGLES, 0, 6);
+	glBindVertexArray(0);
+
+	glBindFramebuffer(GL_FRAMEBUFFER, 0);
+
+	// invalidate caches for the state we touched; the submit run re-sets on demand
+	glViewport(s_presentViewport.x, s_presentViewport.y, s_presentViewport.w, s_presentViewport.h);
+	s_previousShader = -1;
+	s_lastBoundTexture = -1;
+	s_previousBlendMode = BM_NONE;
+	s_previousScissorState = 0;
+}
+
+// NOTE(aalhendi): PS1 draws into VRAM and can texture from that same VRAM. Native
+// mirrors that by flushing pending CPU VRAM writes, then packing the presented
+// framebuffer into the persistent RG8 VRAM texture. CPU-side VRAM reads pull from
+// that packed texture lazily, avoiding the old per-frame GPU->CPU->GPU round trip.
+void NativeRenderer_StoreFrameBuffer(int x, int y, int w, int h)
+{
+	NativePerf_BeginScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_STORE);
+
+	NativeRenderer_UpdateVRAM();
+	NativeRenderer_BlitBackbufferToFramebufferTex(x, y, w, h);
+	NativeRenderer_GpuPackFramebufferToVRAM(x, y, w, h);
+	s_cpuVRAMMirrorStale = 1;
+	s_framebufferNeedsUpdate = 1;
+	s_lastBoundTexture = -1;
+
 	NativePerf_EndScope(NATIVE_PERF_BUCKET_FRAMEBUFFER_STORE);
 }
 
 void NativeRenderer_CopyVRAM(u16 *src, int x, int y, int w, int h, int dst_x, int dst_y)
 {
-	s_vramNeedsUpdate = 1;
-
 	int stride = w;
 
 	if (!src)
 	{
-		// NOTE(aalhendi): MoveImage copies from PS1 VRAM. If native has a pending
-		// host framebuffer readback, pull it into the CPU VRAM mirror before the
-		// copy. Do not schedule a later readback here; boot TIM display moves are
-		// immediately followed by DrawSync, and a deferred black backbuffer read can
-		// wipe the copied splash page.
+		// NOTE(aalhendi): MoveImage copies from PS1 VRAM. If GPU feedback has made
+		// the CPU mirror stale, pull the packed VRAM texture before reading it.
 		NativeRenderer_ReadFramebufferDataToVRAM();
 		src = vram;
 		stride = VRAM_WIDTH;
@@ -1652,10 +1888,14 @@ void NativeRenderer_CopyVRAM(u16 *src, int x, int y, int w, int h, int dst_x, in
 		dst += VRAM_WIDTH;
 		src += stride;
 	}
+
+	NativeRenderer_MarkVRAMDirty(dst_x, dst_y, w, h);
 }
 
 void NativeRenderer_ReadVRAM(u16 *dst, int x, int y, int dst_w, int dst_h)
 {
+	NativeRenderer_ReadFramebufferDataToVRAM();
+
 	u16 *src = vram + x + VRAM_WIDTH * y;
 
 	for (int i = 0; i < dst_h; i++)
@@ -1679,7 +1919,7 @@ int NativeRenderer_CaptureVRAMState(void *dst, int dstSize)
 	}
 
 	// NOTE(aalhendi): Save-states own the CPU-side PSX VRAM mirror, not GL
-	// textures. Pull pending framebuffer copies into the mirror first.
+	// textures. Pull pending GPU-authored VRAM into the mirror first.
 	NativeRenderer_ReadFramebufferDataToVRAM();
 	SDL_memcpy(dst, vram, sizeof(vram));
 	return 1;
@@ -1696,8 +1936,9 @@ int NativeRenderer_RestoreVRAMState(const void *src, int srcSize)
 
 	SDL_memcpy(vram, src, sizeof(vram));
 	// NOTE(aalhendi): Restored VRAM is authoritative PSX state. Host GL caches
-	// are rebuildable, so mark the texture dirty and drop stale bindings.
-	s_vramNeedsUpdate = 1;
+	// are rebuildable, so mark all of VRAM dirty and drop stale bindings.
+	NativeRenderer_MarkVRAMDirty(0, 0, VRAM_WIDTH, VRAM_HEIGHT);
+	s_cpuVRAMMirrorStale = 0;
 	s_framebufferNeedsUpdate = 0;
 	s_previousFramebuffer = zeroRect;
 	s_previousOffscreen = zeroRect;
@@ -1715,15 +1956,20 @@ void NativeRenderer_UpdateVRAM(void)
 	}
 
 	NativePerf_BeginScope(NATIVE_PERF_BUCKET_RENDERER_UPDATE_VRAM);
-	s_vramNeedsUpdate = 0;
 
-	s_vramTexture = s_vramTexturesDouble[s_vramTextureIndex];
-	s_vramTextureIndex++;
-	s_vramTextureIndex &= 1;
+	const int rectCount = s_vramDirtyRectCount;
+	s_vramNeedsUpdate = 0;
+	s_vramDirtyRectCount = 0;
 
 	glBindTexture(GL_TEXTURE_2D, s_vramTexture);
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, VRAM_WIDTH);
+	for (int i = 0; i < rectCount; i++)
+	{
+		RECT16 r = s_vramDirtyRects[i];
+		glTexSubImage2D(GL_TEXTURE_2D, 0, r.x, r.y, r.w, r.h, VRAM_FORMAT, GL_UNSIGNED_BYTE, vram + (size_t)r.y * VRAM_WIDTH + r.x);
+	}
+	glPixelStorei(GL_UNPACK_ROW_LENGTH, 0);
 
-	glTexImage2D(GL_TEXTURE_2D, 0, VRAM_INTERNAL_FORMAT, VRAM_WIDTH, VRAM_HEIGHT, 0, VRAM_FORMAT, GL_UNSIGNED_BYTE, vram);
 	NativePerf_EndScope(NATIVE_PERF_BUCKET_RENDERER_UPDATE_VRAM);
 }
 

--- a/platform/native_str.c
+++ b/platform/native_str.c
@@ -259,24 +259,61 @@ internal s32 NativeSTR_ReadAcCode(struct NativeSTRBitReader *br, u16 *outCode)
 	return 0;
 }
 
+// NOTE(aalhendi): Separable IDCT, kept bit-identical to the old direct 2D sum by
+// preserving unrounded s64 row transforms and applying the same final rounding.
+// Zero coefficient rows are skipped before the column pass.
 internal void NativeSTR_IDCT(const s32 *coefficients, s32 *out)
 {
+	s64 rowPass[64];
+	u8 rowNonZero[8];
 	s32 x;
 	s32 y;
+	s32 u;
+	s32 v;
+
+	for (v = 0; v < 8; v++)
+	{
+		const s32 *row = &coefficients[v * 8];
+
+		rowNonZero[v] = 0;
+		for (u = 0; u < 8; u++)
+		{
+			if (row[u] != 0)
+			{
+				rowNonZero[v] = 1;
+				break;
+			}
+		}
+
+		if (!rowNonZero[v])
+		{
+			continue;
+		}
+
+		for (x = 0; x < 8; x++)
+		{
+			s64 sum = 0;
+
+			for (u = 0; u < 8; u++)
+			{
+				sum += (s64)s_idctBasis[x][u] * row[u];
+			}
+
+			rowPass[v * 8 + x] = sum;
+		}
+	}
 
 	for (y = 0; y < 8; y++)
 	{
 		for (x = 0; x < 8; x++)
 		{
 			s64 sum = 0;
-			s32 u;
-			s32 v;
 
 			for (v = 0; v < 8; v++)
 			{
-				for (u = 0; u < 8; u++)
+				if (rowNonZero[v])
 				{
-					sum += (s64)s_idctBasis[x][u] * s_idctBasis[y][v] * coefficients[v * 8 + u];
+					sum += (s64)s_idctBasis[y][v] * rowPass[v * 8 + x];
 				}
 			}
 


### PR DESCRIPTION
This PR reduces host CPU/GPU/RAM usage by making the native layer behave more like the actual PS1 hardware instead of doing per-frame busywork the console never did. The PS1 doesn't re-upload VRAM every frame, doesn't copy the framebuffer back to memory "just in case", and doesn't validate its OT. Emulating that faithfully turned out to remove a lot of wasted work and fixed some accuracy bugs along the way.

Everything is PC side only (`platform/` and `include/platform/`). No game code paths were changed.

## VRAM pipeline

* Single persistent VRAM texture in `GL_RG8`. The PS1 has one 1MB VRAM and page flips two display windows inside it, it never keeps two full copies. The old double buffered `RG32F` setup (2x4MB) only existed to orphan the texture on the per frame full re-upload, which is gone now. With NEAREST sampling RG8 returns byte/255 exactly, so the shader input is identical and CLUT reconstruction doesn't change.
* Dirty rect tracking: every VRAM write (ClearImage, LoadImage, MoveImage, feedback packs) unions into an accumulated rect and `UpdateVRAM` uploads just that box with `glTexSubImage2D`, instead of re-uploading the whole 1MB every frame.
* The framebuffer feedback barrier now packs the captured frame into the VRAM texture with a fragment shader (`ctr_pack_shader`), writing the same `r5|g5<<5|b5<<10|stp<<15` layout the CPU pack produced. Before, this was a `glGetTexImage` GPU to CPU readback plus a CPU pack plus a full VRAM re-upload, every time an effect like heat haze sampled the screen. I checked the shader against the CPU pack at runtime on live frames before removing the readback, output is bit identical.
* `DrawSync` no longer copies the framebuffer back to the CPU VRAM mirror every frame. Real DrawSync only waits for the GPU. The consumers that actually need the frame pull it on demand: `StoreImage` (pause screen grab) pulls it to exactly the VRAM y it reads, MoveImage/LoadImage2/save states go through the existing path.
* The remaining on demand readbacks reuse a persistent scratch buffer instead of malloc/free per call.

On my reference machine (Intel Core i5 1035G1 + GeForce MX130 laptop) this took the average native layer frame work from ~2.97ms to ~1.5ms.

## Feedback capture fix (this bug exists in master too)

`BlitBackbufferToFramebufferTex` used VRAM absolute dst coordinates on a texture that is only sized w*h. For the high framebuffer (y=0x128, so dst rows 296..512 of a 216 row texture) GL clipped the entire blit and the capture silently kept the previous frame. So every other frame, feedback effects sampled a 1 frame old image: the warpball screen warp drew a double image while moving, heat haze showed a ghost copy of the HUD when they overlapped, and the clock blur hid it because it samples the previous frame by design anyway.

The blit destination is now region relative, `(0,h)-(w,0)`. All consumers already read the capture relative to 0,0 and place it at the VRAM x/y themselves, so nothing else changes. Master has the same bug, it's just partially masked there because the synchronous readback path refreshes VRAM more often.

Also, `Platform_EndScene` now packs the presented frame into VRAM (GPU side) once per frame. Screen copy effects that sample VRAM without going through the feedback barrier (the item/clock blur) were reading whatever the last barrier left there, or the boot splash if none had fired yet.

## Frame clock

* The emulated VBlank now runs at the real NTSC 240p rate. Per psx-spx GPU timings that's 263 scanlines x 3413 GPU cycles at 53.693175MHz = 59.826Hz, not a flat 60Hz. The whole game paces off this clock (logic frames, RCNT1 into `elapsedTimeMS`, audio step), so 60Hz was running everything about 0.3% fast. The advance uses the exact rational `freq*897619/53693175` with a running remainder, no float drift.
* The wait itself got cheaper. On console VSync waits on the VBlank IRQ and the hardware wakes the CPU at the exact instant for free. We now do the bulk of the wait with `SDL_DelayPrecise` (which yields the CPU and uses the best per OS primitive internally) and only busy spin the final 200us, down from a 1000us spin. The vblank schedule is absolute so a slightly late wake can't accumulate drift.
* Added debug logs in `Platform_EndScene`: every 512 presented frames they print the frame clock in its PS1 representation (vblanks per frame, RCNT1 hblank ticks per frame, the retail `elapsedTimeMS` this maps to, and wall fps, each next to its console reference). Steady gameplay reads 2.000 vblanks/frame, 526.000 ticks, elapsedTimeMS 32.085, fps 29.908 (console is 2 / 526 / ~32 / 29.913).

## OT walk cost

* The per node registered range validation now only runs in `CTR_INTERNAL` builds, where all the debug tooling lives and nothing changes. Release keeps just the null/alignment guard. PS1 DMA never validates the chain, it just follows it, and this check ran for every primitive of every frame.
* `NativeGpuLinks_FindHostRange` got a last hit cache: consecutive OT nodes almost always live in the same arena, so the previous hit resolves most lookups with a single compare. Pure hint, falls back to the full scan.

## MDEC (STR video)

Rewrote the IDCT from the direct O(64^2) 2D sum to the row column separable form: pass 1 keeps the exact unrounded per row 1D transforms in s64, pass 2 accumulates them and applies the same single final rounding the 2D version used. That makes it bit identical by plain integer distributivity, and it's also how the real MDEC computes it (two 1D passes). Rows whose dequantized coefficients are all zero skip both passes, which is most rows in typical sparse STR blocks, so per block work drops from 8192 multiplies to a few hundred.

Validated at runtime by decoding 8192 blocks of real stream data through both implementations: 0 mismatches. The reference implementation was removed after that.

For completeness I also went over the SPU/XA side against psx-spx and left it alone on purpose: it already uses the real 512 entry Gaussian interpolation table, the 29 tap / 7 phase XA zigzag resampler, a full ADSR state machine and the register driven comb reverb with the 39 tap FIR. The tables are the accuracy there, and mixing costs under 1% of a core, so there was nothing worth touching.

## Testing

* GPU pack vs CPU pack compared bit for bit at runtime before deleting the readback path.
* Separable IDCT vs the old 2D IDCT compared on 8192 real video blocks, 0 mismatches.
* Frame clock verified in game with the debug logs above.
* Play tested: heat haze, warpball screen warp, item/clock blur, pause screen grab, FMV/STR playback, save states, boot splashes.

PD: summary made with claude fable lol.