### PR TITLE
CTR physics accuracy and fixing architecture differences on PC

### DIFF
--- a/game/221.c
+++ b/game/221.c
@@ -261,7 +261,7 @@ void CC_EndEvent_DrawMenu()
 	{
 		token->flags &= ~(HIDE_MODEL);
 		token->matrix.t[0] = UI_ConvertX_2(pos.x, CC_SCREEN_DEPTH);
-		token->matrix.t[1] = UI_ConvertY_2(0xA2 - 0x18, CC_SCREEN_DEPTH);
+		token->matrix.t[1] = UI_ConvertY_2(pos.y - 0x18, CC_SCREEN_DEPTH);
 	}
 
 	if (elapsedFrames > CTR_SECONDS_TO_FRAMES(1))

--- a/game/222.c
+++ b/game/222.c
@@ -73,7 +73,9 @@ void AA_EndEvent_DrawMenu(void)
 	struct Instance *hudR = sdata->ptrHudR;
 	struct Instance *hudLetters[3] = {hudC, hudT, hudR};
 	struct Instance *hudToken = sdata->ptrToken;
-	struct UiElement2D *hudCTR = &data.hud_1P_P1[AA_CTR_HUD_SLOT];
+
+	// Retail indexes the HUD table by player count here, same as AA_EndEvent_DisplayTime.
+	struct UiElement2D *hudCTR = &data.hudStructPtr[numPlayers - 1][AA_CTR_HUD_SLOT];
 
 	s32 elapsedFrames = sdata->framesSinceRaceEnded;
 
@@ -209,7 +211,10 @@ void AA_EndEvent_DrawMenu(void)
 
 			for (s32 i = 0; i < 3; i++)
 			{
-				hudLetters[i]->matrix.t[0] = UI_ConvertX_2(letterPos.x + (letterScaleOffset * (i * 12)) + (i * 29), AA_SCREEN_DEPTH);
+				// Retail narrows the scaled offset to 16 bits before adding it to letterPos.x.
+				s16 letterScaleSpread = (s16)(letterScaleOffset * (i * 12));
+
+				hudLetters[i]->matrix.t[0] = UI_ConvertX_2(letterPos.x + letterScaleSpread + (i * 29), AA_SCREEN_DEPTH);
 				hudLetters[i]->matrix.t[1] = UI_ConvertY_2(letterPos.y - (i & 1), AA_SCREEN_DEPTH);
 			}
 
@@ -217,7 +222,7 @@ void AA_EndEvent_DrawMenu(void)
 			{
 				hudR->depthBiasNormal = 1;
 				hudToken->flags &= ~HIDE_MODEL;
-				hudToken->matrix.t[0] = hudT->matrix.t[0];
+				hudToken->matrix.t[0] = UI_ConvertX_2(letterPos.x + (s16)(letterScaleOffset * 12) + 29, AA_SCREEN_DEPTH);
 				hudToken->matrix.t[1] = UI_ConvertY_2(letterPos.y + 0x18, AA_SCREEN_DEPTH);
 
 				if ((tokenAwardTextFrame >= 0) && (hudToken->scale.x < AA_TOKEN_GROW_LIMIT))
@@ -236,6 +241,7 @@ void AA_EndEvent_DrawMenu(void)
 					DecalFont_DrawLine(sdata->lngStrings[LNG_CTR_TOKEN_AWARDED], textPos.x, textPos.y, FONT_BIG, textColor);
 				}
 			}
+
 		}
 
 		// If you did not collect all 3 letters (C, T, and R), or you lost the race.
@@ -401,15 +407,15 @@ void AA_EndEvent_DrawMenu(void)
 		return;
 	}
 
-	// if the menu is already drawing
-	if (sdata->menuReadyToPass & AA_MENU_READY_FLAG)
-	{
-		return;
-	}
-
 	// If you're in Arcade mode
 	if ((gGT->gameMode1 & ARCADE_MODE) != 0)
 	{
+		// if the menu is already drawing
+		if (sdata->menuReadyToPass & AA_MENU_READY_FLAG)
+		{
+			return;
+		}
+
 		RECTMENU_Show((numPlayers == 1) ? &menu222 : &menu222_2P);
 
 		// record that the menu is drawing
@@ -417,9 +423,27 @@ void AA_EndEvent_DrawMenu(void)
 		return;
 	}
 
-	// If you are in adventure mode
-	if ((gGT->gameMode1 & ADVENTURE_MODE) == 0)
+	// Retail re-derives the win condition here instead of reusing the value
+	// computed at the top of the frame; both read the same fields.
+	if (!didWin)
 	{
+		// if the menu is already drawing
+		if (sdata->menuReadyToPass & AA_MENU_READY_FLAG)
+		{
+			return;
+		}
+
+		DecalFont_DrawLine(sdata->lngStrings[LNG_PRESS_TO_CONTINUE], 0x100, 0xbe, FONT_BIG, (JUSTIFY_CENTER | ORANGE));
+
+		// If you have not pressed X
+		if ((sdata->AnyPlayerTap & AA_CONFIRM_BUTTON_MASK) == 0)
+		{
+			return;
+		}
+
+		RECTMENU_ClearInput();
+		RECTMENU_Show(&data.menuRetryExit);
+		sdata->menuReadyToPass |= AA_MENU_READY_FLAG;
 		return;
 	}
 
@@ -431,18 +455,9 @@ void AA_EndEvent_DrawMenu(void)
 		return;
 	}
 
-	// === If Pressed X ===
+	// === If Pressed X, and you won the race ===
 
 	RECTMENU_ClearInput();
-
-	if (!didWin)
-	{
-		RECTMENU_Show(&data.menuRetryExit);
-		sdata->menuReadyToPass |= AA_MENU_READY_FLAG;
-		return;
-	}
-
-	// === If you won the race ===
 
 	sdata->framesSinceRaceEnded = 0;
 	sdata->numIconsEOR = 1;

--- a/game/223.c
+++ b/game/223.c
@@ -261,6 +261,18 @@ void RR_EndEvent_DrawMenu(void)
 	relic->matrix.t[0] = pos.x;
 	relic->matrix.t[1] = pos.y;
 
+	// NOTE: retail interpolates here but never consumes the result; the time-crate
+	// interpolation right below overwrites pos. Kept for parity with retail.
+	elapsedFrames = sdata->framesSinceRaceEnded;
+	if (elapsedFrames >= RR_FLYOUT_START_FRAME)
+	{
+		UI_Lerp2D_Linear(pos.v, 0x100, 0x20, 0x100, -0x44, elapsedFrames - RR_FLYOUT_FRAME_OFFSET, RR_LERP_FRAMES);
+	}
+	else
+	{
+		UI_Lerp2D_Linear(pos.v, 0x28a, 0x20, 0x100, 0x20, elapsedFrames, RR_LERP_FRAMES);
+	}
+
 	// Draw Time Crates
 	// Reset local frame counter
 	elapsedFrames = sdata->framesSinceRaceEnded;
@@ -290,6 +302,10 @@ void RR_EndEvent_DrawMenu(void)
 	// if collected all time boxes in level
 	if (driver->numTimeCrates == gGT->timeCratesInLEV)
 	{
+		// Retail formats the countdown default here, before the PERFECT block.
+		char *str = countdownText;
+		sprintf(str, s_countdownStartFormat223);
+
 		// copy to local frame counter
 		elapsedFrames = sdata->framesSinceRaceEnded;
 
@@ -302,6 +318,10 @@ void RR_EndEvent_DrawMenu(void)
 			// 170 frames after the first 80
 			if (elapsedFrames >= RR_PERFECT_FLYOUT_OFFSET)
 			{
+				// Retail restarts the interpolation at the fly-out frame, so the
+				// text slides off instead of snapping to the end position.
+				elapsedFrames -= RR_PERFECT_FLYOUT_OFFSET;
+
 				startX = 0x100;
 				endX = 0x296;
 			}
@@ -320,9 +340,9 @@ void RR_EndEvent_DrawMenu(void)
 				}
 			}
 
-			UI_Lerp2D_Linear(pos.v, startX, 0, endX, 0, elapsedFrames, RR_LERP_FRAMES);
+			UI_Lerp2D_Linear(pos.v, startX, 0x8a, endX, 0x8a, elapsedFrames, RR_LERP_FRAMES);
 
-			DecalFont_DrawLine(sdata->lngStrings[LNG_PERFECT], pos.x, 0x8a, 1, textColor);
+			DecalFont_DrawLine(sdata->lngStrings[LNG_PERFECT], pos.x, pos.y, 1, textColor);
 		}
 
 		// copy to local frame counter
@@ -331,9 +351,6 @@ void RR_EndEvent_DrawMenu(void)
 		// fade-in COUNTDOWN (-10, -9, -8...)
 		if (elapsedFrames >= RR_COUNTDOWN_START_FRAME)
 		{
-			char *str = countdownText;
-			sprintf(str, s_countdownStartFormat223);
-
 			drawCountdown = 0;
 
 			if (elapsedFrames >= RR_FLYOUT_FRAME_OFFSET)
@@ -459,6 +476,7 @@ skipRelicAwarded:
 	// copy to local frame counter
 	elapsedFrames = sdata->framesSinceRaceEnded;
 
+	pos.x = 0;
 	pos.y = 0xc;
 
 	// if race ended more than 490 frames ago

--- a/game/224.c
+++ b/game/224.c
@@ -104,11 +104,10 @@ void TT_EndEvent_DrawMenu(void)
 		// first transition is race clock
 		elapsedFrames -= TT_RACE_CLOCK_HOLD_FRAMES;
 
-		// race time
-		UI_Lerp2D_Linear(pos.v, -0x64, 90, 0x100, 90, elapsedFrames, TT_LERP_FRAMES);
-
-		TT_EndEvent_DisplayTime(pos.x, pos.y, sdata->flags_timeTrialEndOfRace);
-
+		// Retail draws the three result messages first and the race time last, so
+		// the flash flags raised below are already visible to TT_EndEvent_DisplayTime
+		// on the same frame.
+		s32 raceTimeFrame = elapsedFrames;
 
 		// Blink Orange/White
 		s32 textColor = (gGT->timer & 1) ? 0xffff8000 : 0xffff8004;
@@ -117,36 +116,49 @@ void TT_EndEvent_DrawMenu(void)
 		// "new high score" 1 second later
 		elapsedFrames -= TT_RESULT_MESSAGE_STEP_FRAMES;
 
-		if ((elapsedFrames > 0) &&
-
-		    // if there is a new high score
-		    gGT->newHighScoreIndex > -1)
+		if (elapsedFrames > 0)
 		{
 			UI_Lerp2D_Linear(pos.v, 0x264, 122, 0x100, 122, elapsedFrames, TT_LERP_FRAMES);
 
-			DecalFont_DrawLine(lngStrings[LNG_NEW_HIGH_SCORE], pos.x, pos.y, FONT_BIG, textColor);
+			// if there is a new high score
+			if (gGT->newHighScoreIndex > -1)
+			{
+				DecalFont_DrawLine(lngStrings[LNG_NEW_HIGH_SCORE], pos.x, pos.y, FONT_BIG, textColor);
 
-			// Total time should flash
-			sdata->flags_timeTrialEndOfRace |= TT_TOTAL_TIME_FLASH_FLAG;
+				// Total time should flash
+				sdata->flags_timeTrialEndOfRace |= TT_TOTAL_TIME_FLASH_FLAG;
+			}
 		}
 
 
 		// "new best lap" 1 second later
 		elapsedFrames -= TT_RESULT_MESSAGE_STEP_FRAMES;
 
-		if ((elapsedFrames > 0) &&
-
-		    // if got new best lap
-		    ((gameModeEnd & NEW_BEST_LAP) != 0))
+		if (elapsedFrames > 0)
 		{
 			UI_Lerp2D_Linear(pos.v, -0x64, 142, 0x100, 142, elapsedFrames, TT_LERP_FRAMES);
 
-			DecalFont_DrawLine(lngStrings[LNG_NEW_BEST_LAP], pos.x, pos.y, FONT_BIG, textColor);
-
-			if ((u32)gGT->lapIndexNewBest < 3)
+			// if got new best lap
+			if ((gameModeEnd & NEW_BEST_LAP) != 0)
 			{
-				// make the best row start flashing
-				sdata->flags_timeTrialEndOfRace |= 1 << (TT_BEST_LAP_FLASH_FLAG_FIRST + gGT->lapIndexNewBest);
+				DecalFont_DrawLine(lngStrings[LNG_NEW_BEST_LAP], pos.x, pos.y, FONT_BIG, textColor);
+
+				// make the best row start flashing. Retail tests the lap index
+				// against each value instead of shifting by it, so a value outside
+				// 0-2 simply raises nothing (and there is no shift to overflow).
+				if (gGT->lapIndexNewBest == 0)
+				{
+					sdata->flags_timeTrialEndOfRace |= 1 << TT_BEST_LAP_FLASH_FLAG_FIRST;
+				}
+				else if (gGT->lapIndexNewBest == 1)
+				{
+					sdata->flags_timeTrialEndOfRace |= 1 << (TT_BEST_LAP_FLASH_FLAG_FIRST + 1);
+				}
+
+				if (gGT->lapIndexNewBest == 2)
+				{
+					sdata->flags_timeTrialEndOfRace |= 1 << (TT_BEST_LAP_FLASH_FLAG_FIRST + 2);
+				}
 			}
 		}
 
@@ -156,25 +168,31 @@ void TT_EndEvent_DrawMenu(void)
 
 		s32 nTropyEventFlags = NTROPY_JUST_BEAT | NTROPY_JUST_OPENED;
 
-		if ((elapsedFrames > 0) &&
-
-		    // if just open, or beat, n tropy
-		    ((gameModeEnd & nTropyEventFlags) != 0))
+		if (elapsedFrames > 0)
 		{
 			UI_Lerp2D_Linear(pos.v, 0x264, 162, 0x100, 162, elapsedFrames, TT_LERP_FRAMES);
 
-			char *nTropyString;
-			if ((gameModeEnd & NTROPY_JUST_OPENED) != 0)
+			// if just open, or beat, n tropy
+			if ((gameModeEnd & nTropyEventFlags) != 0)
 			{
-				nTropyString = lngStrings[LNG_N_TROPY_OPENED];
-			}
-			else
-			{
-				nTropyString = lngStrings[LNG_N_TROPY_BEATEN];
-			}
+				char *nTropyString;
+				if ((gameModeEnd & NTROPY_JUST_OPENED) != 0)
+				{
+					nTropyString = lngStrings[LNG_N_TROPY_OPENED];
+				}
+				else
+				{
+					nTropyString = lngStrings[LNG_N_TROPY_BEATEN];
+				}
 
-			DecalFont_DrawLine(nTropyString, pos.x, pos.y, FONT_BIG, textColor);
+				DecalFont_DrawLine(nTropyString, pos.x, pos.y, FONT_BIG, textColor);
+			}
 		}
+
+		// race time
+		UI_Lerp2D_Linear(pos.v, -0x64, 90, 0x100, 90, raceTimeFrame, TT_LERP_FRAMES);
+
+		TT_EndEvent_DisplayTime(pos.x, pos.y, sdata->flags_timeTrialEndOfRace);
 
 		DecalFont_DrawLine(lngStrings[LNG_PRESS_TO_CONTINUE], 0x100, 0xbe, FONT_BIG, 0xffff8000);
 
@@ -188,12 +206,14 @@ void TT_EndEvent_DrawMenu(void)
 		return;
 	}
 
+	// start drawing the high score menu that shows the top 5 best times.
+	// Retail raises this for every frame past the result screen, including the
+	// ones where the end-of-race menu is already up.
+	gGT->gameModeEnd |= DRAW_HIGH_SCORES;
+
 	// Return at bottom of IF block
 	if (elapsedFrames < TT_FINAL_MENU_START_FRAME)
 	{
-		// start drawing the high score menu that shows the top 5 best times
-		gGT->gameModeEnd |= DRAW_HIGH_SCORES;
-
 		if ((gameModeEnd & NEW_HIGH_SCORE) == 0)
 		{
 			// ====== Draw High Score ===========

--- a/game/225.c
+++ b/game/225.c
@@ -107,9 +107,10 @@ void VB_EndEvent_DrawMenu(void)
 			teamPlayerCount[gGT->drivers[player]->BattleHUD.teamID]++;
 		}
 
-		titleY = (VB_BATTLE_BLOCK_BOTTOM_Y -
-		          ((gGT->battleSetup.numTeams - 1) * VB_BATTLE_TEAM_SCORE_GAP + numPlayers * VB_BATTLE_TITLE_PLAYER_HEIGHT + VB_BATTLE_BLOCK_HEADER_HEIGHT)) >>
-		         1;
+		// Retail shifts this logically (srl), not arithmetically.
+		titleY = (s16)CTR_MipsSrl(VB_BATTLE_BLOCK_BOTTOM_Y - ((gGT->battleSetup.numTeams - 1) * VB_BATTLE_TEAM_SCORE_GAP +
+		                                                      numPlayers * VB_BATTLE_TITLE_PLAYER_HEIGHT + VB_BATTLE_BLOCK_HEADER_HEIGHT),
+		                          1);
 	}
 
 	// Disable drawing lines between multiplayer screens
@@ -175,15 +176,17 @@ void VB_EndEvent_DrawMenu(void)
 		{
 			rankTextY = s_vsStandingsYByPlayerCount[playerCountIndex][VB_POSY_P1 + standingsIndex];
 
-			struct Driver *driver = gGT->drivers[entityID];
-			struct Icon *icon = gGT->ptrIcons[data.MetaDataCharacters[data.characterIDs[driver->driverID]].iconID];
+			// Retail indexes the character table by the standings slot, not by driverID.
+			struct Icon *icon = gGT->ptrIcons[data.MetaDataCharacters[data.characterIDs[entityID]].iconID];
 
 			DecalHUD_DrawPolyFT4(icon, pos.x, rankTextY, &gGT->backBuffer->primMem, gGT->pushBuffer_UI.ptrOT, VB_ICON_TRANSPARENCY, VB_ICON_SCALE);
 		}
 		else
 		{
 			s16 numPlayersOnTeam = teamPlayerCount[entityID];
-			rankTextY = currRowY + (numPlayersOnTeam * VB_BATTLE_PLAYER_ICON_SPACING) / 2 - VB_BATTLE_RANK_TEXT_CENTER_Y;
+
+			// Retail narrows the block height to 16 bits before halving it.
+			rankTextY = currRowY + (s16)(numPlayersOnTeam * VB_BATTLE_PLAYER_ICON_SPACING) / 2 - VB_BATTLE_RANK_TEXT_CENTER_Y;
 
 			s16 iconSlot = 0;
 			for (s32 player = 0; player < numPlayers; player++)
@@ -195,7 +198,8 @@ void VB_EndEvent_DrawMenu(void)
 					continue;
 				}
 
-				struct Icon *icon = gGT->ptrIcons[data.MetaDataCharacters[data.characterIDs[driver->driverID]].iconID];
+				// Retail indexes the character table by the player slot, not by driverID.
+				struct Icon *icon = gGT->ptrIcons[data.MetaDataCharacters[data.characterIDs[player]].iconID];
 				DecalHUD_DrawPolyFT4(icon, pos.x, currRowY + iconSlot * VB_BATTLE_PLAYER_ICON_SPACING, &gGT->backBuffer->primMem, gGT->pushBuffer_UI.ptrOT,
 				                     VB_ICON_TRANSPARENCY, VB_ICON_SCALE);
 				iconSlot++;
@@ -235,6 +239,9 @@ void VB_EndEvent_DrawMenu(void)
 
 		rowDelay += VB_ROW_STAGGER_FRAMES;
 
+		// standingsScore is a 32-bit field (sw/lw in MainGameEnd_Initialize) that
+		// only ever holds a sign-extended 16-bit value; retail keeps this carry-over
+		// copy in a 16-bit stack slot, so the narrowing is deliberate.
 		previousStandingsScore = (s16)gGT->battleSetup.standingsScore[entityID];
 		sprintf(text, "%d%s", displayedRank + 1, sdata->lngStrings[VB_STANDINGS_SUFFIX_FIRST + displayedRank]);
 

--- a/game/226/226_00_DrawLevelOvr1P.c
+++ b/game/226/226_00_DrawLevelOvr1P.c
@@ -7701,11 +7701,23 @@ static int Ovr226_800a15c0_EmitFullDynamicExtraFace3(struct PushBuffer *pb, stru
 static int Ovr226_800a15d4_FullDynamicHelperSlot0(struct PushBuffer *pb, struct PrimMem *primMem, struct QuadBlock *block,
                                                   struct DrawLevelOvr1PScratchVertex *projected, struct TextureLayout *texture, int depth)
 {
-	if (!Ovr226_800a1548_EmitFullDynamicFace1(pb, primMem, block, projected, texture, depth, DRAW_LEVEL_OVR1P_DIRECT_QUAD))
+	//Retail 0x800a15d4 does not call the shared Face1/Face2
+	// emitters. It inlines its own index sets, closing both sub-quads on corner
+	// vertex 3 instead of on edge midpoints 7 and 8:
+	//   0x800a15d4: fp+80,20,120,60  -> {4,1,6,3} == GridMixedFaceIndices[0]
+	//   0x800a15ec: fp+100,120,40,60 -> {5,6,2,3} == GridMixedFaceIndices[1]
+	//   0x800a160c: b 0x800a1534     -> {0,4,5,6} == GridFaceIndices[0]
+	// Face1/Face2 stop at those midpoints, so the two sub-quads came out half
+	// height and the wedge against corner 3 was emitted by nothing. The
+	// projected-grid family already uses this Mixed[0]/Mixed[1]/GridFace[0]
+	// sequence for the same near-mask slot.
+	if (!DrawLevelOvr1P_EmitFullDynamicTerminalFacePreserveSlot(pb, primMem, block, projected, sDrawLevelOvr1PGridMixedFaceIndices[0], 0, texture, depth,
+	                                                           DRAW_LEVEL_OVR1P_DIRECT_QUAD))
 	{
 		return 0;
 	}
-	if (!Ovr226_800a155c_EmitFullDynamicFace2(pb, primMem, block, projected, texture, depth, DRAW_LEVEL_OVR1P_DIRECT_QUAD))
+	if (!DrawLevelOvr1P_EmitFullDynamicTerminalFacePreserveSlot(pb, primMem, block, projected, sDrawLevelOvr1PGridMixedFaceIndices[1], 0, texture, depth,
+	                                                           DRAW_LEVEL_OVR1P_DIRECT_QUAD))
 	{
 		return 0;
 	}

--- a/game/231/RB_Warpball.c
+++ b/game/231/RB_Warpball.c
@@ -300,7 +300,9 @@ void RB_Warpball_SeekDriver(struct TrackerWeapon *tw, u32 checkpointIndex, struc
 	// pointer to path node
 	struct CheckpointNode *cn = &first[checkpointIndex];
 
-	while ((d->distanceToFinish_curr <= (u32)(cn->distToFinish << 3)) &&
+	// Retail compares this signed (`slt` at 0x800aed3c in overlay 231), not
+	// unsigned; distanceToFinish_curr is a signed word.
+	while ((d->distanceToFinish_curr <= (cn->distToFinish << 3)) &&
 
 	       // node is not first node
 	       (cn != first))

--- a/game/BOTS.c
+++ b/game/BOTS.c
@@ -91,11 +91,14 @@ int BOTS_Adv_NumTimesLostEvent(int numLost)
 		numLost = BOTS_ADV_MAX_LOSS_DIFFICULTY_INDEX;
 	}
 
-	return data.advDifficulty[numLost];
+	// retail truncates the index to 16 bits before scaling it by the element
+	// size (`sll 16; sra 15`), so a value like 0x10000 passes the clamp above
+	// and still indexes element 0.
+	return data.advDifficulty[(s16)numLost];
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x800123e0-0x80012440
-void BOTS_SetGlobalNavData(u16 index)
+void BOTS_SetGlobalNavData(s16 index)
 {
 	sdata->lastPathIndex = index;
 
@@ -223,6 +226,8 @@ void BOTS_Adv_AdjustDifficulty(void)
 
 	if ((gameMode1 & ARCADE_MODE) != 0)
 	{
+		// arcadeDifficulty is a 32-bit field (retail has lw/sw on it elsewhere),
+		// but retail reads it here with `lhu`: the (u16) truncation is real.
 		currDifficulty = (u16)gGT->arcadeDifficulty;
 
 		if ((gameMode2 & CHEAT_SUPERHARD) != 0)
@@ -235,12 +240,15 @@ void BOTS_Adv_AdjustDifficulty(void)
 	else if ((gameMode1 & ADVENTURE_CUP) != 0)
 	{
 		s32 track = gGT->cup.trackIndex;
-		s32 lostModifier = BOTS_Adv_NumTimesLostEvent(sdata->advProgress.timesLostCupRace[track]);
-		s32 maxDifficulty = track * BOTS_ADV_NORMAL_SCALE;
+		s32 lostModifier;
+		s32 maxDifficulty;
 
+		// retail calls BOTS_Adv_NumTimesLostEvent once per branch, not once
+		// hoisted above the `if` -- keep the call count at 4 like the ASM.
 		if (gGT->cup.cupID == 4)
 		{
-			lostModifier -= BOTS_ADV_HIGH_TIER_LOSS_BASE;
+			lostModifier = BOTS_Adv_NumTimesLostEvent(sdata->advProgress.timesLostCupRace[track]) - BOTS_ADV_HIGH_TIER_LOSS_BASE;
+			maxDifficulty = track * BOTS_ADV_NORMAL_SCALE;
 
 			if ((gameMode2 & CHEAT_ADV) != 0)
 			{
@@ -250,7 +258,8 @@ void BOTS_Adv_AdjustDifficulty(void)
 		}
 		else
 		{
-			lostModifier -= BOTS_ADV_CUP_LOSS_BASE;
+			lostModifier = BOTS_Adv_NumTimesLostEvent(sdata->advProgress.timesLostCupRace[track]) - BOTS_ADV_CUP_LOSS_BASE;
+			maxDifficulty = track * BOTS_ADV_NORMAL_SCALE;
 
 			if ((gameMode2 & CHEAT_ADV) != 0)
 			{
@@ -278,7 +287,10 @@ void BOTS_Adv_AdjustDifficulty(void)
 	}
 	else
 	{
-		s16 numTrophies = (s16)gGT->currAdvProfile.numTrophies + 1;
+		// numTrophies is a 32-bit field (retail has lw/sw on it elsewhere) that
+		// retail reads here with `lhu` + sign-extend, so the (s16) is real. The
+		// local, though, stays 32-bit: retail never re-narrows it after the +1.
+		s32 numTrophies = (s16)gGT->currAdvProfile.numTrophies + 1;
 		s32 lostModifier = BOTS_Adv_NumTimesLostEvent(sdata->advProgress.timesLostRacePerLev[gGT->levelID]) - BOTS_ADV_RACE_LOSS_BASE;
 		s32 maxDifficulty = numTrophies * BOTS_ADV_RACE_TROPHY_SCALE;
 
@@ -381,7 +393,7 @@ void BOTS_Adv_AdjustDifficulty(void)
 
 	for (s16 i = 0; i < BOTS_MAX_KARTS; i++)
 	{
-		sdata->driver_pathIndexIDs[i] = pathOrder[(u8)sdata->kartSpawnOrderArray[i]];
+		sdata->driver_pathIndexIDs[i] = pathOrder[sdata->kartSpawnOrderArray[i]];
 	}
 
 	if ((gameMode1 & ADVENTURE_BOSS) != 0)
@@ -415,7 +427,7 @@ void BOTS_Adv_AdjustDifficulty(void)
 
 		for (s16 i = 0; i < BOTS_MAX_KARTS; i++)
 		{
-			sdata->accelerateOrder[i] = accelOrder[(u8)sdata->kartSpawnOrderArray[i]];
+			sdata->accelerateOrder[i] = accelOrder[sdata->kartSpawnOrderArray[i]];
 		}
 	}
 
@@ -429,7 +441,7 @@ void BOTS_Adv_AdjustDifficulty(void)
 		{
 			if ((gGT->numPlyrCurrGame <= i) && (bestPoints < gGT->cup.points[i]))
 			{
-				bestPoints = (s16)gGT->cup.points[i];
+				bestPoints = gGT->cup.points[i];
 				bestDriverIndex = i;
 			}
 
@@ -492,7 +504,7 @@ void BOTS_UpdateGlobals(void)
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80013444-0x800135d8
-void BOTS_SetRotation(struct Driver *bot, int useSpawnYaw)
+void BOTS_SetRotation(struct Driver *bot, s16 useSpawnYaw)
 {
 	struct NavFrame *nf = bot->botData.botNavFrame;
 
@@ -1095,12 +1107,13 @@ UpdateTireColorTimer:
 				struct Driver *otherDriver = NULL; // iVar4
 				if ((botFlags & BOT_FLAG_ESTIMATE_NAV) == 0)
 				{
-					int iVar3 = 1000;
-					s16 sVar7 = 1000;
+					// retail keeps this in a 16-bit slot: every compare on it is
+					// preceded by `sll 16`, and so is the `< 3` check below.
+					s16 iVar3 = 1000;
 					struct BotData *botData;
 
 					for (botData = (struct BotData *)LIST_GetFirstItem(&sdata->navBotList[botDriver->botData.botPath]); botData != NULL;
-					     botData = (struct BotData *)LIST_GetNextItem((struct Item *)botData), sVar7 = (s16)iVar3)
+					     botData = (struct BotData *)LIST_GetNextItem((struct Item *)botData))
 					{
 						struct Driver *driverFromBotData = (struct Driver *)((char *)botData - offsetof(struct Driver, botData));
 
@@ -1111,13 +1124,13 @@ UpdateTireColorTimer:
 
 
 						// Find the signed index difference between nav frames on this path.
-						int iVar13 = (int)(botData->botNavFrame - botDriver->botData.botNavFrame);
+						s16 iVar13 = (s16)(botData->botNavFrame - botDriver->botData.botNavFrame);
 
 						// if "other" botData driver is behind "this" botDriver driver,
 						if (iVar13 < 0)
 						{
 							// assume number of points "away" is large (add track length)
-							iVar13 = CTR_MipsAddLo(iVar13, sdata->NavPath_ptrHeader[botDriver->botData.botPath]->numPoints);
+							iVar13 = (s16)CTR_MipsAddLo(iVar13, sdata->NavPath_ptrHeader[botDriver->botData.botPath]->numPoints);
 						}
 
 						// find closest "other" botData driver
@@ -1132,7 +1145,7 @@ UpdateTireColorTimer:
 					}
 
 					// If two drivers are within 3 navframe points of each other
-					if ((otherDriver != NULL) && (sVar7 < 3))
+					if ((otherDriver != NULL) && (iVar3 < 3))
 					{
 						int diff = CTR_MipsSubLo(botDriver->distanceToFinish_curr, otherDriver->distanceToFinish_curr);
 
@@ -1161,7 +1174,7 @@ UpdateTireColorTimer:
 								LIST_AddFront(&sdata->navBotList[newPathID], &botDriver->botData.item);
 
 								struct NavFrame *firstNavFrameOnPath = sdata->NavPath_ptrNavFrameArray[newPathID];
-								botDriver->botData.botNavFrame = &firstNavFrameOnPath[newFrameIndex & BOTS_PATH_CHANGE_FRAME_MASK];
+								botDriver->botData.botNavFrame = &firstNavFrameOnPath[newFrameIndex];
 
 								BOTS_SetRotation(botDriver, 0);
 
@@ -1231,7 +1244,8 @@ UpdateTireColorTimer:
 			}
 			else
 			{
-				int driverRank = botDriver->driverRank; // uVar8
+				// retail keeps this in a 16-bit slot (`sll 16` before every use)
+				s16 driverRank = botDriver->driverRank; // uVar8
 				b32 isInAdvArcadeOrVSCup = false;       // bVar1
 
 				if (((gGT->gameMode1 & ADVENTURE_CUP) != 0) || ((gGT->gameMode2 & CUP_ANY_KIND) != 0))
@@ -1303,7 +1317,7 @@ UpdateTireColorTimer:
 				    CTR_MipsAddLo(sdata->arcade_difficultyParams[driverRank], difficultyStat));
 
 				int otherDifficultyStat; // iVar13
-				if (isInAdvArcadeOrVSCup && ((driverRank & 0xffff) == 0))
+				if (isInAdvArcadeOrVSCup && (driverRank == 0))
 				{
 					if (complexDifficultyStat < 1)
 					{
@@ -1538,7 +1552,9 @@ UpdateTireColorTimer:
 					}
 				}
 
-				int navFrameIndexOnPath = (int)(navFrameCurr - sdata->NavPath_ptrNavFrameArray[botDriver->botData.botPath]);
+				// retail truncates this to 16 bits inside the divide-by-20
+				// sequence itself (`sll 14; sra 16`), not just at the compares
+				s16 navFrameIndexOnPath = (s16)(navFrameCurr - sdata->NavPath_ptrNavFrameArray[botDriver->botData.botPath]);
 
 				if ((data.botsThrottle[botPathIndex] <= navFrameIndexOnPath) && (navFrameIndexOnPath < CTR_MipsAddLo(data.botsThrottle[botPathIndex], 0xb)) &&
 				    (9000 < botDriver->botData.aiPhysics.speedLinear))
@@ -1556,7 +1572,7 @@ UpdateTireColorTimer:
 
 				if (botDriver->botData.aiPhysics.speedLinear < velocityAccountingForTerrain)
 				{
-					u32 var = (u32)navFrameCurr->rot[3];
+					u32 var = navFrameCurr->rot[3];
 					int sinOfAngle = MATH_Sin(CTR_MipsSll(var, 4));
 
 					botDriver->botData.aiPhysics.speedLinear =
@@ -2512,7 +2528,8 @@ UpdateTireColorTimer:
 		}
 
 		botDriver->wheelRotation = (s16)CTR_MipsAddLo((u16)botDriver->wheelRotation, sVar7);
-		botDriver->simpTurnState = (s8)(u8)botDriver->botData.aiPhysics.simpTurnState;
+		// retail copies byte to byte here (lbu 0x5c2 -> sb 0x4b)
+		botDriver->simpTurnState = botDriver->botData.aiPhysics.simpTurnState;
 	}
 
 	botDriver->rotCurr.x = botDriver->botData.aiRot.x;
@@ -3052,7 +3069,7 @@ void BOTS_GotoStartingLine(struct Driver *d)
 	d->actionsFlagSet |= ACTION_BOT;
 
 	// calculate Y rotation
-	s16 rotY = (s16)CTR_MipsSll((u8)d->botData.estimateRotNav[1], BOTS_ROT_BYTE_SHIFT);
+	s16 rotY = (s16)CTR_MipsSll(d->botData.estimateRotNav[1], BOTS_ROT_BYTE_SHIFT);
 
 	// every possible Y rotation
 	d->botData.ai_rotY_608 = rotY;
@@ -3072,8 +3089,10 @@ void BOTS_GotoStartingLine(struct Driver *d)
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80017164-0x80017318.
 struct Driver *BOTS_Driver_Init(int driverID)
 {
-	s8 initialNavPathIndex = sdata->driver_pathIndexIDs[driverID];
-	s8 navPathIndex = initialNavPathIndex;
+	// retail narrows the table entry to signed 8-bit, but keeps both indices
+	// in 16-bit slots (`sll 16` on every compare)
+	s16 initialNavPathIndex = (s8)sdata->driver_pathIndexIDs[driverID];
+	s16 navPathIndex = initialNavPathIndex;
 	while (1)
 	{
 		s16 navPathPointsCount = sdata->NavPath_ptrHeader[navPathIndex]->numPoints;
@@ -3103,9 +3122,9 @@ struct Driver *BOTS_Driver_Init(int driverID)
 	    // creation flags
 	    SIZE_RELATIVE_POOL_BUCKET(DRIVER_NTSC_RETAIL_SIZE, NONE, LARGE, ROBOT),
 
-	    BOTS_ThTick_Drive, // behavior
-	    0,                 //"robotcar",	// debug name
-	    0                  // thread relative
+	    BOTS_ThTick_Drive,    // behavior
+	    rdata.s_robotcar,     // debug name
+	    0                     // thread relative
 	);
 
 	struct Driver *d = t->object;
@@ -3135,8 +3154,10 @@ void BOTS_Driver_Convert(struct Driver *d)
 
 	UI_RaceEnd_GetDriverClock(d);
 
-	s8 initialNavPathIndex = sdata->driver_pathIndexIDs[d->driverID];
-	s8 navPathIndex = initialNavPathIndex;
+	// retail narrows the table entry to signed 8-bit, but keeps both indices
+	// in 16-bit slots (`sll 16` on every compare)
+	s16 initialNavPathIndex = (s8)sdata->driver_pathIndexIDs[d->driverID];
+	s16 navPathIndex = initialNavPathIndex;
 	while (1)
 	{
 		s16 navPathPointsCount = sdata->NavPath_ptrHeader[navPathIndex]->numPoints;

--- a/game/CAM.c
+++ b/game/CAM.c
@@ -18,23 +18,27 @@ static u32 CAM_SkyboxGlow_PackXY(s32 x, s32 y)
 	return ((u32)(u16)x) | ((u32)(u16)y << 16);
 }
 
+// ratio is unbounded (the gradient endpoints can sit arbitrarily close), so the
+// products below rely on MIPS mult/mflo wraparound, not on C signed overflow.
 static u32 CAM_SkyboxGlow_LerpColor(u32 from, u32 to, s32 ratio)
 {
-	s32 r = (u8)from + ((((s32)(u8)to - (s32)(u8)from) * ratio) >> 12);
-	s32 g = (u8)(from >> 8) + ((((s32)(u8)(to >> 8) - (s32)(u8)(from >> 8)) * ratio) >> 12);
-	s32 b = (u8)(from >> 16) + ((((s32)(u8)(to >> 16) - (s32)(u8)(from >> 16)) * ratio) >> 12);
+	s32 r = (u8)from + CTR_MipsSra(CTR_MipsMulLo((s32)(u8)to - (s32)(u8)from, ratio), 12);
+	s32 g = (u8)(from >> 8) + CTR_MipsSra(CTR_MipsMulLo((s32)(u8)(to >> 8) - (s32)(u8)(from >> 8), ratio), 12);
+	s32 b = (u8)(from >> 16) + CTR_MipsSra(CTR_MipsMulLo((s32)(u8)(to >> 16) - (s32)(u8)(from >> 16), ratio), 12);
 
 	return ((u32)(u8)r) | ((u32)(u8)g << 8) | ((u32)(u8)b << 16);
 }
 
 static s32 CAM_SkyboxGlow_FixedRatio(s32 numerator, s32 denominator)
 {
-	return (numerator << 12) / denominator;
+	// numerator is negative whenever the gradient edge is off-screen, which is
+	// most of the time: shifting it left is a plain sll in retail.
+	return CTR_MipsDiv(CTR_MipsSll(numerator, 12), denominator);
 }
 
 static s32 CAM_SkyboxGlow_ScreenX(s32 screenWidth, s32 ratio)
 {
-	return (screenWidth * ratio) >> 12;
+	return CTR_MipsSra(CTR_MipsMulLo(screenWidth, ratio), 12);
 }
 
 static s32 CAM_SkyboxGlow_Div2TowardZero(s32 value)
@@ -45,7 +49,7 @@ static s32 CAM_SkyboxGlow_Div2TowardZero(s32 value)
 
 static s32 CAM_SkyboxGlow_CalcCenterY(struct PushBuffer *pb)
 {
-	s32 pitch = (pb->rot.x - 0x800) * 0x78;
+	s32 pitch = CTR_MipsMulLo(pb->rot.x - 0x800, 0x78);
 	s32 height = (s16)pb->rect.h;
 
 	if (pitch < 0)
@@ -58,13 +62,15 @@ static s32 CAM_SkyboxGlow_CalcCenterY(struct PushBuffer *pb)
 
 static s32 CAM_SkyboxGlow_CalcTilt(struct PushBuffer *pb)
 {
+	// Retail calls MATH_Sin first, then MATH_Cos.
+	s32 sine = MATH_Sin(pb->rot.z);
 	s32 cosine = MATH_Cos(pb->rot.z);
 	if (cosine == 0)
 	{
 		cosine = 1;
 	}
 
-	s32 ratio = (MATH_Sin(pb->rot.z) << 12) / cosine;
+	s32 ratio = CTR_MipsDiv(CTR_MipsSll(sine, 12), cosine);
 	s32 shifted = (s32)((u32)ratio << 8);
 	shifted >>= 12;
 
@@ -300,8 +306,9 @@ void CAM_SkyboxGlow(struct SkyboxGlowGradient *grad, struct PushBuffer *pb, stru
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8001861c-0x80018818
 void CAM_ClearScreen(struct GameTracker *gGT)
 {
-	s8 numPlyr = gGT->numPlyrCurrGame;
-	s8 swap = gGT->swapchainIndex;
+	// Retail reads numPlyrCurrGame with lbu and swapchainIndex with lw.
+	u8 numPlyr = gGT->numPlyrCurrGame;
+	s32 swap = gGT->swapchainIndex;
 	struct Level *level1 = gGT->level1;
 	struct DB *backDB = gGT->backBuffer;
 	TILE *tile = backDB->primMem.cursor;
@@ -312,13 +319,16 @@ void CAM_ClearScreen(struct GameTracker *gGT)
 		uint32_t *endOT = &pb->ptrOT[0x3FF];
 
 		s16 x = pb->rect.x;
-		s16 y = pb->rect.y + swap * 0x128;
+		// Retail builds swap*0x128 with a wrapping sll/addu chain, never a
+		// trapping multiply.
+		s16 y = (s16)CTR_MipsAddLo(pb->rect.y, CTR_MipsMulLo(swap, 0x128));
 		s16 w = pb->rect.w;
 		s16 h = pb->rect.h;
 
 		// cam up/down changes where the line splits.
 		// At 0x800, camera looks straight, and line is perfectly midpoint
-		s32 splitLine = (((s32)pb->rot.x - 0x800) >> 3) + (h >> 1);
+		// Retail divides the height by 2 (truncating toward zero), it does not shift.
+		s32 splitLine = (((s32)pb->rot.x - 0x800) >> 3) + (h / 2);
 
 		if (splitLine < 0)
 		{
@@ -387,8 +397,8 @@ void CAM_Init(struct CameraDC *cDC, s32 cameraID, struct Driver *d, struct PushB
 	cDC->driverToFollow = d;
 	cDC->pushBuffer = pb;
 
-	// dont set cameraMode to zero,
-	// memset makes it already zero
+	// Redundant after the memset, but retail emits the store (sh zero, 0x9a).
+	cDC->cameraMode = 0;
 
 	cDC->flags |= CAMERA_FLAG_DIRECTION_CHANGED;
 }
@@ -814,8 +824,8 @@ void CAM_FollowDriver_AngleAxis(struct CameraDC *cDC, struct Driver *d, struct C
 void CAM_StartLine_FlyIn(struct FlyInData *flyInData, s16 maxFrames, s32 frame, SVec3 *desiredPos, SVec3 *desiredRot)
 {
 	struct Level *lev = sdata->gGT->level1;
-	s32 frameIndex = (frame << 0x10) >> 4;
-	s32 frameRatio = frameIndex / maxFrames;
+	s32 frameIndex = CTR_MipsSra(CTR_MipsSll(frame, 0x10), 4);
+	s32 frameRatio = CTR_MipsDiv(frameIndex, maxFrames);
 	s32 countEnd = flyInData->frameCount1;
 	s16 count = flyInData->frameCount2;
 	SVECTOR local_78;
@@ -842,7 +852,10 @@ void CAM_StartLine_FlyIn(struct FlyInData *flyInData, s16 maxFrames, s32 frame, 
 	else
 	{
 		pathEnd = (s16 *)(flyInData->ptrEnd + countEnd * 6 - 0xc);
-		pathRatioEnd = 0;
+
+		// Retail parks the ratio at 0x1000 here, not 0: the `& 0xfff` below
+		// zeroes it either way, but keep the constant retail uses.
+		pathRatioEnd = 0x1000;
 	}
 
 	if (pathIndex < flyInData->frameCount2 - 1)
@@ -852,7 +865,7 @@ void CAM_StartLine_FlyIn(struct FlyInData *flyInData, s16 maxFrames, s32 frame, 
 	else
 	{
 		pathStart = (s16 *)(flyInData->ptrStart + flyInData->frameCount2 * 6 - 0xc);
-		frameRatio = 0;
+		frameRatio = 0x1000;
 	}
 
 	s32 ratio = count * pathRatioEnd & 0xfff;
@@ -894,7 +907,7 @@ void CAM_StartLine_FlyIn(struct FlyInData *flyInData, s16 maxFrames, s32 frame, 
 	s16 deltaZ = desiredPos->z - (s16)transformed.vz;
 
 	desiredRot->y = (s16)ratan2(deltaX, deltaZ);
-	desiredRot->x = 0x800 - (s16)ratan2(deltaY, SquareRoot0(deltaX * deltaX + deltaZ * deltaZ));
+	desiredRot->x = 0x800 - (s16)ratan2(deltaY, SquareRoot0_stub(deltaX * deltaX + deltaZ * deltaZ));
 	desiredRot->z = 0;
 }
 
@@ -985,7 +998,7 @@ u32 CAM_FollowDriver_TrackPath(struct CameraDC *cDC, SVec3 *pos, s32 speed, s32 
 
 	if (segmentLength != 0)
 	{
-		ratio = (pathProgress << 12) / segmentLength;
+		ratio = CTR_MipsDiv(CTR_MipsSll(pathProgress, 12), segmentLength);
 	}
 	else
 	{
@@ -1022,7 +1035,7 @@ void CAM_LookAtPosition(struct CameraScratchWork *scratchWork, Vec3 *positions, 
 	cam->dir.y = dirY;
 	cam->dir.z = dirZ;
 
-	s32 distance = SquareRoot0_stub(CAM_MulLo(dirX, dirX) + CAM_MulLo(dirZ, dirZ));
+	s32 distance = SquareRoot0_stub(CTR_MipsAddLo(CAM_MulLo(dirX, dirX), CAM_MulLo(dirZ, dirZ)));
 
 	// rotations
 	desiredRot->x = 0x800 - (s16)ratan2(dirY, distance);
@@ -1085,7 +1098,8 @@ void CAM_FollowDriver_Normal(struct CameraDC *cDC, struct Driver *d, SVec3 *push
 	struct CameraScratch *cam = &scratchWork->camera;
 	struct GameTracker *gGT = sdata->gGT;
 	struct GamepadBuffer *pad = &sdata->gGamepads->gamepad[d->driverID];
-	s8 state;
+	// Retail reads both kartState and terrain_type with lbu, and both are u8.
+	u8 state;
 	s16 uVar8;
 	s16 sVar10;
 	u32 backupFlags;
@@ -1445,7 +1459,7 @@ void CAM_FollowDriver_Normal(struct CameraDC *cDC, struct Driver *d, SVec3 *push
 
 	else
 	{
-		state = (s8)quad->terrain_type;
+		state = quad->terrain_type;
 
 		// Mud, Water, or FastWater
 		if (((state == 0xe) || (state == 4)) || (state == 0xd))
@@ -1695,21 +1709,22 @@ LAB_8001ab04:
 
 		if (iVar12 <= iVar14)
 		{
-			x = x >> 1;
+			// Retail halves with a truncate-toward-zero divide, not a shift.
+			x = x / 2;
 
 			if (iVar12 < x)
 			{
 				// Sine(angle)
-				x = MATH_Sin(0x400 - (iVar12 << 10) / x);
+				x = MATH_Sin(0x400 - CTR_MipsDiv(CTR_MipsSll(iVar12, 10), x));
 
 				cDC->transitionBlend = (s16)(x / 2) + 0x800;
 			}
 			else
 			{
-				iVar14 = (iVar12 - iVar14) * 0x400;
+				iVar14 = CTR_MipsSll(iVar12 - iVar14, 10);
 
 				// Cosine(angle)
-				x = MATH_Cos(iVar14 / x);
+				x = MATH_Cos(CTR_MipsDiv(iVar14, x));
 
 				cDC->transitionBlend = 0x800 - (s16)(x / 2);
 			}
@@ -2014,7 +2029,8 @@ void CAM_ThTick(struct Thread *t)
 		sVar5 = psVar21[2];
 		sVar1 = psVar21[3];
 
-		iVar7 = VehCalc_MapToRange((s32)sVar6 * (s32)sVar6 + (s32)sVar5 * (s32)sVar5 + (s32)sVar1 * (s32)sVar1, 0x10000, 0x190000, 0x80, 0xf0);
+		iVar7 = VehCalc_MapToRange(CTR_MipsAddLo(CTR_MipsAddLo(CAM_MulLo(sVar6, sVar6), CAM_MulLo(sVar5, sVar5)), CAM_MulLo(sVar1, sVar1)), 0x10000,
+		                           0x190000, 0x80, 0xf0);
 
 		cDC->angleAxisLerpRatio = (s16)iVar7;
 		break;
@@ -2134,8 +2150,8 @@ SkipNewCameraEOR:
 						    CTR_MipsAddLo(CTR_MipsAddLo(CAM_MulLo((s32)stackMemPos.x, (s32)stackMemPos.x), CAM_MulLo((s32)stackMemPos.y, (s32)stackMemPos.y)),
 						                  CAM_MulLo((s32)stackMemPos.z, (s32)stackMemPos.z)));
 
-						iVar18 = cDC->trackPathProgress << 0xc;
-						iVar25 = iVar18 / iVar24;
+						iVar18 = CTR_MipsSll(cDC->trackPathProgress, 0xc);
+						iVar25 = CTR_MipsDiv(iVar18, iVar24);
 						/*
 						if (iVar24 == 0)
 						{
@@ -2146,7 +2162,8 @@ SkipNewCameraEOR:
 						    trap(0x1800);
 						}
 						*/
-						cDC->trackPathProgress = cDC->trackPathProgress + (((cDC->transitionFrame * 0x1000) / 0x1e) * iVar7 >> 0xc);
+						cDC->trackPathProgress =
+						    cDC->trackPathProgress + CTR_MipsSra(CTR_MipsMulLo((cDC->transitionFrame * 0x1000) / 0x1e, iVar7), 0xc);
 						if (iVar8 < 1)
 						{
 							if (iVar25 < 0x1001)
@@ -2171,9 +2188,11 @@ SkipNewCameraEOR:
 						{
 							psVar21 = cDC->eorModeData.pointPath.endPos.v;
 						}
-						pb->pos.x = psVar21[0] + (s16)((stackMemPos.x * iVar25) >> 0xc);
-						pb->pos.y = psVar21[1] + (s16)((stackMemPos.y * iVar25) >> 0xc);
-						pb->pos.z = psVar21[2] + (s16)((stackMemPos.z * iVar25) >> 0xc);
+						// iVar25 is a raw (progress << 12) / distance quotient, so these
+						// products rely on mult/mflo wraparound.
+						pb->pos.x = psVar21[0] + (s16)CTR_MipsSra(CTR_MipsMulLo(stackMemPos.x, iVar25), 0xc);
+						pb->pos.y = psVar21[1] + (s16)CTR_MipsSra(CTR_MipsMulLo(stackMemPos.y, iVar25), 0xc);
+						pb->pos.z = psVar21[2] + (s16)CTR_MipsSra(CTR_MipsMulLo(stackMemPos.z, iVar25), 0xc);
 						goto LAB_8001c11c;
 					}
 					if (sVar6 == 7)
@@ -2292,9 +2311,9 @@ SkipNewCameraEOR:
 
 				iVar7 = SquareRoot0_stub(CTR_MipsAddLo(CAM_MulLo(camThTick->dir.x, camThTick->dir.x), CAM_MulLo(camThTick->dir.z, camThTick->dir.z)));
 				iVar17 = (s32)(cDC->transitionTo).pos.x;
-				iVar24 = (iVar7 - (cDC->transitionTo).pos.y) * iVar17;
+				iVar24 = CTR_MipsMulLo(CTR_MipsSubLo(iVar7, (cDC->transitionTo).pos.y), iVar17);
 				iVar8 = (s32)(cDC->transitionTo).pos.z;
-				iVar7 = iVar24 / iVar8;
+				iVar7 = CTR_MipsDiv(iVar24, iVar8);
 				/*
 				if (iVar8 == 0)
 				{
@@ -2318,12 +2337,13 @@ SkipNewCameraEOR:
 				pb->distanceToScreen_PREV = pb->distanceToScreen_CURR + iVar7;
 			}
 
-			Vec3 cameraProbePos;
-			cameraProbePos.x = (s32)pb->pos.x;
-			cameraProbePos.y = (s32)pb->pos.y;
-			cameraProbePos.z = (s32)pb->pos.z;
+			// Retail probes from camThTick->pos (scratchpad), not from a stack
+			// copy, same as the sibling call in CAM_FollowDriver_Normal.
+			camThTick->pos.x = (s32)pb->pos.x;
+			camThTick->pos.y = (s32)pb->pos.y;
+			camThTick->pos.z = (s32)pb->pos.z;
 
-			CAM_FindClosestQuadblock((struct ScratchpadStruct *)scratchWork, cDC, d, &cameraProbePos);
+			CAM_FindClosestQuadblock((struct ScratchpadStruct *)scratchWork, cDC, d, &camThTick->pos);
 			goto LAB_8001c150;
 		}
 	}

--- a/game/COLL.c
+++ b/game/COLL.c
@@ -545,9 +545,10 @@ void COLL_FIXED_BSPLEAF_TestInstance(struct BSP *node, struct ScratchpadStruct *
 		return;
 	}
 
-	// check every instance hitbox until
-	// end of list (null flag) is found
-	for (/**/; bspArray->flag != 0; bspArray++)
+	// check every instance hitbox until end of list is found. retail loads the
+	// whole word at +0x0 (flag and id together) and stops on 0x00000000, so a
+	// zero flag alone does not terminate the list.
+	for (/**/; (bspArray->flag != 0) || (bspArray->id != 0); bspArray++)
 	{
 		struct BoundingBox *bbox = &bspArray->box;
 
@@ -1209,8 +1210,8 @@ internal void COLL_FIXED_PlayerSearch_SetupSearch(struct ScratchpadStruct *sps, 
 		sps->Union.QuadBlockColl.searchFlags = COLL_SEARCH_HIGH_LOD;
 	}
 
+	// retail clears only these two here; boolDidTouchHitbox is left alone.
 	sps->boolDidTouchQuadblock = 0;
-	sps->boolDidTouchHitbox = 0;
 	sps->numTrianglesTested = 0;
 
 	sps->bbox.min.x = probeTop.x;
@@ -1610,11 +1611,15 @@ BlendNormal:
 			{
 				s32 screenOffset = Coll_MipsAbsS32((s8)d->Screen_OffsetY);
 
+				// retail branches to UpdateGroundOffset on both rejects here, so
+				// distanceFromGround keeps its previous value instead of being
+				// reset below.
 				if ((screenOffset < 4) && ((d->terrainMeta1->flags & TERRAIN_FLAG_RAISE_GROUND_OFFSET) != 0))
 				{
 					d->distanceFromGround = 4;
-					goto UpdateGroundOffset;
 				}
+
+				goto UpdateGroundOffset;
 			}
 		}
 

--- a/game/CTR/CTR_Matrix.c
+++ b/game/CTR/CTR_Matrix.c
@@ -27,19 +27,19 @@ void CTR_MatrixToRot(SVECTOR *rot, MATRIX *matrix, u32 flags)
 	// char unk_CTR_MatrixToRot_table[0x10];
 // NOTE(aalhendi): CTR_NATIVE mirrors the retail 0x8008d004 table through sdata.
 #if defined(CTR_NATIVE)
-	char *table1 = &sdata->unk_CTR_MatrixToRot_table[0];
-	char *table2 = &sdata->unk_CTR_MatrixToRot_table[8];
+	const u8 *table1 = &sdata->unk_CTR_MatrixToRot_table[0];
+	const u8 *table2 = &sdata->unk_CTR_MatrixToRot_table[8];
 #else
-	char *table1 = (char *)0x8008d004;
-	char *table2 = (char *)0x8008d00C;
+	const u8 *table1 = (const u8 *)0x8008d004;
+	const u8 *table2 = (const u8 *)0x8008d00C;
 #endif
 
 	// take value from the first table
-	u32 t1value = (u32)table1[flags >> 3 & 3];
+	u32 t1value = table1[flags >> 3 & 3];
 
 	// take two values from the second table
-	u32 t2value1 = (u32)table2[t1value + uVar7];
-	u32 t2value2 = (u32)table2[t1value - (uVar7 - 1)];
+	u32 t2value1 = table2[t1value + uVar7];
+	u32 t2value2 = table2[t1value - (uVar7 - 1)];
 
 	// bit 1 check - uses flipped matrix or smth?
 	if ((flags >> 1 & 1) == 1)
@@ -109,10 +109,12 @@ void CTR_MatrixToRot(SVECTOR *rot, MATRIX *matrix, u32 flags)
 	// bit 0 check - switch XZ axis
 	if ((flags & 1) == 1)
 	{
-		// can use pad for the swap
-		rot->pad = rot->vx;
+		// Retail swaps through registers (lhu/lh then two sh) and never writes
+		// rot->pad here; using the pad field as scratch would add a store to the
+		// caller's struct that retail does not make.
+		s16 swapTmp = rot->vx;
 		rot->vx = rot->vz;
-		rot->vz = rot->pad;
+		rot->vz = swapTmp;
 	}
 
 	// copy flags to pad

--- a/game/ElimBG.c
+++ b/game/ElimBG.c
@@ -24,9 +24,11 @@ enum ElimBGConstants
 	ELIM_BG_TEXTURE_RIGHT_X = 0x240,
 	ELIM_BG_TEXTURE_BACKUP_W = 0x40,
 	ELIM_BG_TEXTURE_BACKUP_H = 0x100,
-	ELIM_BG_PRIMMEM_PAUSE_BYTES = 0xc800,
-	ELIM_BG_RAW_STRIP_OFFSET = 0x800,
-	ELIM_BG_TEXTURE_BACKUP_OFFSET = 0x4800,
+	// All three slot pairs hang off `primMem.end`: retail computes the texture
+	// backup base first and derives the other two by subtracting from it.
+	ELIM_BG_TEXTURE_BACKUP_OFFSET = 0x8000,
+	ELIM_BG_RAW_STRIP_OFFSET = 0x4000,
+	ELIM_BG_PACKED_STRIP_OFFSET = 0x4800,
 	ELIM_BG_SCREEN_W = 0x200,
 	ELIM_BG_SCREEN_H = 0xd8,
 	ELIM_BG_SWAPCHAIN_Y_STRIDE = 0x128,
@@ -44,15 +46,14 @@ enum ElimBGConstants
 	ELIM_BG_VRAM_U_WRAP = 0x80,
 };
 
-CTR_STATIC_ASSERT(ELIM_BG_PRIMMEM_PAUSE_BYTES == 0xc800);
-CTR_STATIC_ASSERT(ELIM_BG_RAW_STRIP_OFFSET == 0x800);
-CTR_STATIC_ASSERT(ELIM_BG_TEXTURE_BACKUP_OFFSET == 0x4800);
+CTR_STATIC_ASSERT(ELIM_BG_TEXTURE_BACKUP_OFFSET == 0x8000);
+CTR_STATIC_ASSERT(ELIM_BG_RAW_STRIP_OFFSET == 0x4000);
+CTR_STATIC_ASSERT(ELIM_BG_PACKED_STRIP_OFFSET == 0x4800);
 CTR_STATIC_ASSERT(ELIM_BG_CHUNK_SOURCE_PIXELS == 0x1000);
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80024524-0x8002459c.
 void ElimBG_SaveScreenshot_Chunk(u16 *packedStrip, u16 *rawStrip, int rawPixelCount)
 {
-	u16 packedPixel;
 	u16 *rawGroupLast;
 
 	if (rawPixelCount == 0)
@@ -62,14 +63,20 @@ void ElimBG_SaveScreenshot_Chunk(u16 *packedStrip, u16 *rawStrip, int rawPixelCo
 
 	rawGroupLast = rawStrip + 3;
 
-	for (; rawPixelCount > 0; rawPixelCount -= 4, rawStrip += 4, rawGroupLast += 4, packedStrip++)
+	// Retail accumulates straight into the destination: four stores per group,
+	// not one store of a local.
+	do
 	{
-		packedPixel = (u16)((rawStrip[0] & 0x3e0) >> 6);
-		packedPixel |= rawGroupLast[-2] >> 2 & 0xf0;
-		packedPixel |= (u16)((rawGroupLast[-1] & 0x3c0) << 2);
-		packedPixel |= (u16)((*rawGroupLast & 0x3c0) << 6);
-		*packedStrip = packedPixel;
-	};
+		*packedStrip = (u16)((rawStrip[0] & 0x3e0) >> 6);
+		*packedStrip |= rawGroupLast[-2] >> 2 & 0xf0;
+		*packedStrip |= (u16)((rawGroupLast[-1] & 0x3c0) << 2);
+		*packedStrip |= (u16)((*rawGroupLast & 0x3c0) << 6);
+
+		rawPixelCount -= 4;
+		rawStrip += 4;
+		rawGroupLast += 4;
+		packedStrip++;
+	} while (rawPixelCount != 0);
 }
 
 
@@ -77,75 +84,75 @@ void ElimBG_SaveScreenshot_Chunk(u16 *packedStrip, u16 *rawStrip, int rawPixelCo
 void ElimBG_SaveScreenshot_Full(struct GameTracker *gGT)
 {
 	int bufferIndex;
-	RECT rect1;
-	RECT rect2;
+	int screenTopY;
+	int stripY;
 	RECT rSrc;
 	RECT rDst;
 
-	bufferIndex = 0;
+	// Retail keeps the two backup rects as one initialized local array,
+	// copied in from .rodata (NTSC-U 926 0x80011064).
+	RECT rect[2] = {
+	    {ELIM_BG_TEXTURE_LEFT_X, 0, ELIM_BG_TEXTURE_BACKUP_W, ELIM_BG_TEXTURE_BACKUP_H},
+	    {ELIM_BG_TEXTURE_RIGHT_X, 0, ELIM_BG_TEXTURE_BACKUP_W, ELIM_BG_TEXTURE_BACKUP_H},
+	};
 
-	rect1.x = ELIM_BG_TEXTURE_LEFT_X;
-	rect1.y = 0;
-	rect1.w = ELIM_BG_TEXTURE_BACKUP_W;
-	rect1.h = ELIM_BG_TEXTURE_BACKUP_H;
-	rect2.x = ELIM_BG_TEXTURE_RIGHT_X;
-	rect2.y = 0;
-	rect2.w = ELIM_BG_TEXTURE_BACKUP_W;
-	rect2.h = ELIM_BG_TEXTURE_BACKUP_H;
+	bufferIndex = 0;
 
 	// vram copy, then overwrite vram with pause image
 
-	u32 start1 = (u32)gGT->db[0].primMem.end;
-	u32 start2 = (u32)gGT->db[1].primMem.end;
-	start1 -= ELIM_BG_PRIMMEM_PAUSE_BYTES;
-	start2 -= ELIM_BG_PRIMMEM_PAUSE_BYTES;
-	gGT->db[0].primMem.end = (void *)start1;
-	gGT->db[1].primMem.end = (void *)start2;
-
-	// double-buffered packed 4bpp pause strips
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0] = (char *)start1;
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB1] = (char *)start2;
+	// backups of the two VRAM pages overwritten by the pause image
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0] = (char *)gGT->db[0].primMem.end - ELIM_BG_TEXTURE_BACKUP_OFFSET;
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1] = (char *)gGT->db[1].primMem.end - ELIM_BG_TEXTURE_BACKUP_OFFSET;
 
 	// double-buffered raw screenshot strips from VRAM
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0] = (char *)(start1 + ELIM_BG_RAW_STRIP_OFFSET);
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB1] = (char *)(start2 + ELIM_BG_RAW_STRIP_OFFSET);
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0] = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0] - ELIM_BG_RAW_STRIP_OFFSET;
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB1] = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1] - ELIM_BG_RAW_STRIP_OFFSET;
 
-	// backups of the two VRAM pages overwritten by the pause image
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0] = (char *)(start1 + ELIM_BG_TEXTURE_BACKUP_OFFSET);
-	sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1] = (char *)(start2 + ELIM_BG_TEXTURE_BACKUP_OFFSET);
+	// double-buffered packed 4bpp pause strips
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0] = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0] - ELIM_BG_PACKED_STRIP_OFFSET;
+	sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB1] = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1] - ELIM_BG_PACKED_STRIP_OFFSET;
+
+	gGT->db[0].primMem.end = sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0];
+	gGT->db[1].primMem.end = sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB1];
 
 	// copy texture vram into PrimMem
-	StoreImage(&rect1, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0]);
-	StoreImage(&rect2, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1]);
+	StoreImage(&rect[0], (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0]);
+	StoreImage(&rect[1], (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1]);
 
 	// === copy screen into texture vram ===
 
+	screenTopY = gGT->swapchainIndex * ELIM_BG_SWAPCHAIN_Y_STRIDE;
+
 	rSrc.x = 0;
-	rSrc.y = gGT->swapchainIndex * ELIM_BG_SWAPCHAIN_Y_STRIDE;
+	rSrc.y = screenTopY;
 	rSrc.w = ELIM_BG_SCREEN_W;
 	rSrc.h = ELIM_BG_STRIP_H;
-
-	rDst.x = ELIM_BG_CAPTURE_VRAM_X;
-	rDst.w = ELIM_BG_CAPTURE_VRAM_W;
-	rDst.h = ELIM_BG_STRIP_H;
 
 	// start the first Store
 	StoreImage(&rSrc, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0]);
 
-	for (rDst.y = 0; rDst.y < (ELIM_BG_SCREEN_H - ELIM_BG_STRIP_H); rDst.y += ELIM_BG_STRIP_H)
+	for (stripY = 0; stripY + ELIM_BG_STRIP_H < ELIM_BG_SCREEN_H; stripY += ELIM_BG_STRIP_H)
 	{
 		bufferIndex = 1 - bufferIndex;
+
+		// start next Store, while processing previous store
+		rSrc.x = 0;
+		rSrc.y = screenTopY + stripY + ELIM_BG_STRIP_H;
+		rSrc.w = ELIM_BG_SCREEN_W;
+		rSrc.h = ELIM_BG_STRIP_H;
 
 		// pause until Store is done
 		DrawSync(0);
 
-		// start next Store, while processing previous store
-		rSrc.y += ELIM_BG_STRIP_H;
-		StoreImage((RECT *)&rSrc, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0 + bufferIndex]);
+		StoreImage(&rSrc, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0 + bufferIndex]);
 
 		ElimBG_SaveScreenshot_Chunk((u16 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0 + (1 - bufferIndex)],
 		                            (u16 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0 + (1 - bufferIndex)], ELIM_BG_CHUNK_SOURCE_PIXELS);
 
+		rDst.x = ELIM_BG_CAPTURE_VRAM_X;
+		rDst.y = stripY;
+		rDst.w = ELIM_BG_CAPTURE_VRAM_W;
+		rDst.h = ELIM_BG_STRIP_H;
 		LoadImage(&rDst, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0 + (1 - bufferIndex)]);
 	}
 
@@ -155,8 +162,13 @@ void ElimBG_SaveScreenshot_Full(struct GameTracker *gGT)
 	ElimBG_SaveScreenshot_Chunk((u16 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0 + bufferIndex],
 	                            (u16 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_RAW_STRIP_DB0 + bufferIndex], ELIM_BG_CHUNK_SOURCE_PIXELS);
 
+	rDst.x = ELIM_BG_CAPTURE_VRAM_X;
+	rDst.y = stripY;
+	rDst.w = ELIM_BG_CAPTURE_VRAM_W;
+	rDst.h = ELIM_BG_STRIP_H;
 	LoadImage(&rDst, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_PACKED_STRIP_DB0 + bufferIndex]);
 
+	rDst.x = ELIM_BG_CAPTURE_VRAM_X;
 	rDst.y = ELIM_BG_FINAL_STRIP_Y;
 	rDst.w = ELIM_BG_FINAL_STRIP_W;
 	rDst.h = 1;
@@ -226,7 +238,8 @@ void ElimBG_ToggleAllInstances(struct GameTracker *gGT, b32 boolGameIsPaused)
 	}
 
 	// Loop through all instances in Instance Pool
-	for (inst = (struct Instance *)gGT->JitPools.instance.taken.first; inst != 0; inst = inst->next)
+	for (inst = (struct Instance *)LIST_GetFirstItem(&gGT->JitPools.instance.taken); inst != 0;
+	     inst = (struct Instance *)LIST_GetNextItem((struct Item *)inst))
 	{
 		ElimBG_ToggleInstance(inst, boolGameIsPaused);
 	}
@@ -236,39 +249,33 @@ void ElimBG_ToggleAllInstances(struct GameTracker *gGT, b32 boolGameIsPaused)
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80024974-0x80024c08.
 void ElimBG_HandleState(struct GameTracker *gGT)
 {
-	s16 screenX;
-	s16 screenY;
-	char textureUByte;
 	int screenXForTpage;
 	int textureU;
 	POLY_FT4 *p;
-	u32 textureX;
-	u32 tpage;
-	u32 textureY;
+	int textureX;
+	u16 tpage;
+	int textureY;
 	int tileX;
-	RECT rect1;
-	RECT rect2;
+
+	// Same initialized local array as ElimBG_SaveScreenshot_Full
+	// (NTSC-U 926 0x80011064).
+	RECT rect[2] = {
+	    {ELIM_BG_TEXTURE_LEFT_X, 0, ELIM_BG_TEXTURE_BACKUP_W, ELIM_BG_TEXTURE_BACKUP_H},
+	    {ELIM_BG_TEXTURE_RIGHT_X, 0, ELIM_BG_TEXTURE_BACKUP_W, ELIM_BG_TEXTURE_BACKUP_H},
+	};
 
 	// if this is last frame of pause
 	if (sdata->pause_state == ELIM_BG_PAUSE_STATE_RESTORE)
 	{
-		rect1.x = ELIM_BG_TEXTURE_LEFT_X;
-		rect1.y = 0;
-		rect1.w = ELIM_BG_TEXTURE_BACKUP_W;
-		rect1.h = ELIM_BG_TEXTURE_BACKUP_H;
-		rect2.x = ELIM_BG_TEXTURE_RIGHT_X;
-		rect2.y = 0;
-		rect2.w = ELIM_BG_TEXTURE_BACKUP_W;
-		rect2.h = ELIM_BG_TEXTURE_BACKUP_H;
-
 		// load from RAM, back to VRAM
-		LoadImage(&rect1, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0]);
-		LoadImage(&rect2, (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1]);
+		LoadImage(&rect[0], (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0]);
+		LoadImage(&rect[1], (u32 *)sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1]);
 
 		DrawSync(0);
 
-		gGT->db[0].primMem.end = (void *)((int)gGT->db[0].primMem.end + ELIM_BG_PRIMMEM_PAUSE_BYTES);
-		gGT->db[1].primMem.end = (void *)((int)gGT->db[1].primMem.end + ELIM_BG_PRIMMEM_PAUSE_BYTES);
+		// retail restores from the saved backup base, not from the current end
+		gGT->db[0].primMem.end = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB0] + ELIM_BG_TEXTURE_BACKUP_OFFSET;
+		gGT->db[1].primMem.end = sdata->PausePtrsVRAM[ELIM_BG_SLOT_TEXTURE_DB1] + ELIM_BG_TEXTURE_BACKUP_OFFSET;
 
 		// Enable all instances
 		ElimBG_ToggleAllInstances(gGT, 0);
@@ -285,7 +292,7 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 		{
 			gGT->renderFlags = (gGT->renderFlags & RENDER_FLAG_CHECKERED_FLAG) | RENDER_FLAG_RENDER_BUCKET;
 
-			gGT->hudFlags &= HUD_FLAG_PAUSE_SCREENSHOT_MASK;
+			sdata->gGT->hudFlags &= HUD_FLAG_PAUSE_SCREENSHOT_MASK;
 
 			ElimBG_SaveScreenshot_Full(gGT);
 
@@ -301,7 +308,6 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 		do
 		{
 			textureY = 0;
-			screenX = (s16)tileX;
 			do
 			{
 				// backBuffer->primMem.cursor
@@ -312,14 +318,12 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 
 				setPolyFT4(p);
 
-				screenY = (s16)textureY;
-
 				// RGB
 				setRGB0(p, ELIM_BG_TILE_COLOR, ELIM_BG_TILE_COLOR, ELIM_BG_TILE_COLOR);
 
 				// four (x,y) positions
-				setXY4(p, screenX, screenY, screenX + ELIM_BG_TILE_W, screenY, screenX, screenY + ELIM_BG_TILE_H, screenX + ELIM_BG_TILE_W,
-				       screenY + ELIM_BG_TILE_H);
+				setXY4(p, tileX, textureY, tileX + ELIM_BG_TILE_W, textureY, tileX, textureY + ELIM_BG_TILE_H, tileX + ELIM_BG_TILE_W,
+				       textureY + ELIM_BG_TILE_H);
 
 				screenXForTpage = tileX;
 				if (tileX < 0)
@@ -327,10 +331,10 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 					screenXForTpage = tileX + 3;
 				}
 				textureX = (screenXForTpage >> 2) + ELIM_BG_TEXTURE_LEFT_X;
-				tpage = getTPage(TEXPAGE_COLOR_4BIT, TRANS_50, (u32)textureX, (u32)textureY);
+				tpage = getTPage(TEXPAGE_COLOR_4BIT, TRANS_50, textureX, textureY);
 
 				// tpage
-				p->tpage = (u16)tpage;
+				p->tpage = tpage;
 
 				// clut
 				p->clut = ELIM_BG_TILE_CLUT;
@@ -341,13 +345,12 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 				p->v1 = textureY;
 
 				// u0
-				textureUByte = (char)textureU;
-				p->u0 = textureUByte;
+				p->u0 = textureU;
 
 				if (textureU + ELIM_BG_VRAM_U_WRAP < ELIM_BG_U_LIMIT)
 				{
 					// u1
-					p->u1 = textureUByte + -ELIM_BG_VRAM_U_WRAP;
+					p->u1 = textureU - ELIM_BG_VRAM_U_WRAP;
 				}
 				else
 				{
@@ -358,14 +361,12 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 				// u2
 				textureU = (textureX - ((tpage << 6) & 0x3c0)) * 4;
 
-				// u2
-				textureUByte = (char)textureU;
-				p->u2 = textureUByte;
+				p->u2 = textureU;
 
 				if (textureU + ELIM_BG_VRAM_U_WRAP < ELIM_BG_U_LIMIT)
 				{
 					// u3
-					p->u3 = textureUByte + -ELIM_BG_VRAM_U_WRAP;
+					p->u3 = textureU - ELIM_BG_VRAM_U_WRAP;
 				}
 				else
 				{
@@ -375,14 +376,14 @@ void ElimBG_HandleState(struct GameTracker *gGT)
 
 				// v3 = v0 + 0x10
 				textureY += ELIM_BG_TILE_H;
-				p->v2 = (char)textureY;
-				p->v3 = (char)textureY;
+				p->v2 = textureY;
+				p->v3 = textureY;
 
 				// pointer to OT mem, and pointer to primitive
-				AddPrim(&gGT->pushBuffer_UI.ptrOT[4], p);
+				AddPrim(&sdata->gGT->pushBuffer_UI.ptrOT[4], p);
 
 				// while v0 (tex coord Y) < screensize
-			} while ((int)textureY < ELIM_BG_SCREEN_H);
+			} while (textureY < ELIM_BG_SCREEN_H);
 
 			// increment u0
 			tileX = tileX + ELIM_BG_TILE_W;

--- a/game/GAMEPAD.c
+++ b/game/GAMEPAD.c
@@ -40,7 +40,7 @@ void GAMEPAD_SetMainMode(void)
 
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x800252a0-0x80025410.
-void GAMEPAD_ProcessState(struct GamepadBuffer *pad, int padState, s16 id)
+void GAMEPAD_ProcessState(struct GamepadBuffer *pad, int padState, int id)
 {
 	int iVar2;
 	int iVar3;
@@ -75,13 +75,17 @@ void GAMEPAD_ProcessState(struct GamepadBuffer *pad, int padState, s16 id)
 				iVar2 = 2;
 			}
 
-			// set to zero by default
-			CTR_WriteU16LE(&pad->motorPower[0], 0);
-
 			// loop through motors
 			for (iVar3 = 0; iVar3 < iVar2; iVar3++)
 			{
 				pad->motorPower[iVar3] = (u8)PadInfoAct(id, iVar3, 4);
+			}
+
+			// zero whatever the pad does not have, retail fills the tail
+			// afterwards instead of clearing both entries up front
+			for (iVar3 = iVar2; iVar3 < 2; iVar3++)
+			{
+				pad->motorPower[iVar3] = 0;
 			}
 
 			PadSetAct(id, &pad->motorSubmit[0], sizeof(pad->motorSubmit));
@@ -740,8 +744,14 @@ void GAMEPAD_ProcessMotors(struct GamepadSystem *gGS)
 					{
 						pad->motorDesired[0] = pad->unk45;
 
-						pad->unk46 -= gGT->elapsedTimeMS;
-						if (pad->unk46 < 1)
+						// retail keeps the subtraction in a 32-bit register and only
+						// stores it once the result is known positive
+						int remaining = pad->unk46 - gGT->elapsedTimeMS;
+						if (remaining > 0)
+						{
+							pad->unk46 = (s16)remaining;
+						}
+						else
 						{
 							pad->unk46 = 0;
 							pad->unk45 = 0;
@@ -857,11 +867,14 @@ void GAMEPAD_ProcessMotors(struct GamepadSystem *gGS)
 	if (totalPower > 60)
 	{
 		int numPads = gGS->numGamepadsConnected;
-		int skipIndex = gGT->timer % numPads;
+
+		// retail divides with `divu`, not `div`
+		int skipIndex = (int)CTR_MipsRemU((u32)gGT->timer, (u32)numPads);
 
 		for (int i = skipIndex; i < skipIndex + numPads && totalPower > 60; i++)
 		{
-			struct GamepadBuffer *pad = &gGS->gamepad[i % numPads];
+			// retail wraps by subtracting, it never emits a second division here
+			struct GamepadBuffer *pad = &gGS->gamepad[(i < numPads) ? i : (i - numPads)];
 
 			if (pad->motorDesired[1] != 0)
 			{
@@ -872,7 +885,7 @@ void GAMEPAD_ProcessMotors(struct GamepadSystem *gGS)
 
 		for (int i = skipIndex; i < skipIndex + numPads && totalPower > 60; i++)
 		{
-			struct GamepadBuffer *pad = &gGS->gamepad[i % numPads];
+			struct GamepadBuffer *pad = &gGS->gamepad[(i < numPads) ? i : (i - numPads)];
 
 			if (pad->motorDesired[0] != 0)
 			{

--- a/game/HOWL/HOWL_Engine.c
+++ b/game/HOWL/HOWL_Engine.c
@@ -2,7 +2,9 @@
 
 // Initialize car engine audio system for one driver
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80028880-0x800289b0
-b32 EngineAudio_InitOnce(u32 soundID, u32 flags)
+// NOTE: retail narrows the first argument to 16 bits at the VehBirth call site
+// (`andi a0, a0, 0xffff`), so the parameter is a u16, not a word.
+b32 EngineAudio_InitOnce(u16 soundID, u32 flags)
 {
 	struct EngineFX *ptrEngineFX;
 	struct ChannelStats *channel;

--- a/game/MAIN/MainFrame.c
+++ b/game/MAIN/MainFrame.c
@@ -188,7 +188,9 @@ void MainFrame_GameLogic(struct GameTracker *gGT, struct GamepadSystem *gGamepad
 		gGT->unk1cc4[4] = 0;
 
 		iVar4 = Timer_GetTime_Elapsed(gGT->clockFrameStart, &gGT->clockFrameStart);
-		iVar4 = (iVar4 << 5) / 100;
+		// retail uses sll/div here and the bgez below shows negatives are expected,
+		// so the shift has to be the wrapping kind rather than C's UB on negatives
+		iVar4 = CTR_MipsDiv(CTR_MipsSll(iVar4, 5), 100);
 
 		gGT->elapsedTimeMS = iVar4;
 		if (iVar4 < 0)

--- a/game/MAIN/MainFrame.c
+++ b/game/MAIN/MainFrame.c
@@ -616,7 +616,10 @@ static int MainFrame_VisMemHasQuad(const int *visFaceList, const struct QuadBloc
 {
 	int quadIndex = (int)(quad - mesh->ptrQuadBlockArray);
 
-	return (visFaceList[quadIndex >> 5] & (1 << (quadIndex & 0x1f))) != 0;
+	// Retail builds the mask with `sllv` (0x80035af0), which is defined for every
+	// count. Plain `1 << 31` would be signed overflow, and bit 31 comes up for
+	// every 32nd quadblock.
+	return (visFaceList[quadIndex >> 5] & CTR_MipsSll(1, quadIndex)) != 0;
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80035684-0x800357b8, unnamed in syms926.

--- a/game/MAIN/MainGameEnd.c
+++ b/game/MAIN/MainGameEnd.c
@@ -188,7 +188,7 @@ static void MainGameEnd_UpdateAdventureLosses(struct GameTracker *gGT, struct Dr
 		return;
 	}
 
-	char *lossCounter;
+	s8 *lossCounter;
 
 	if (IS_BOSS_RACE(gGT->gameMode1))
 	{

--- a/game/MAIN/MainStats.c
+++ b/game/MAIN/MainStats.c
@@ -19,7 +19,7 @@ void MainStats_ClearBattleVS(void)
 void MainStats_RestartRaceCountLoss(void)
 {
 	int index;
-	char *countPtr;
+	s8 *countPtr;
 
 	int gameMode1;
 	struct GameTracker *gGT;

--- a/game/MATH/MATH_3_HitboxMatrix.c
+++ b/game/MATH/MATH_3_HitboxMatrix.c
@@ -1,7 +1,10 @@
 #include <common.h>
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8003d264-0x8003d328.
-MATRIX *MATH_HitboxMatrix(MATRIX *output, MATRIX *input)
+// Retail returns nothing: it ends on `jr $ra` + `nop`, so $v0 is left holding
+// -input->t[2] from the last mtc2. Both retail call sites spill that leftover to
+// the stack and never read it back, so there is no return contract to honour.
+void MATH_HitboxMatrix(MATRIX *output, MATRIX *input)
 {
 	u32 *in = (u32 *)input;
 	u32 *out = (u32 *)output;
@@ -28,6 +31,4 @@ MATRIX *MATH_HitboxMatrix(MATRIX *output, MATRIX *input)
 	out[3] = r31r32;
 	*(s16 *)&out[4] = r33;
 	CTR_GteStoreMAC(output->t);
-
-	return output;
 }

--- a/game/MATH/MATH_7_MatrixStubs.c
+++ b/game/MATH/MATH_7_MatrixStubs.c
@@ -20,32 +20,9 @@ static inline u32 MATH_Matrix_NegHighWord(u32 value)
 	return MATH_Matrix_NegLowWord(value) << 0x10;
 }
 
-static void MATH_Matrix_TrigSinCos(u32 angle, u32 *sinOut, u32 *cosOut)
-{
-	u32 trig = CTR_ReadU32LE(&data.trigApprox[ANG_MODULO_HALF_PI(angle)]);
-	u32 quadrant = angle & ANG_QUADRANT_BITS;
-
-	if (quadrant == 0)
-	{
-		*sinOut = trig & 0xffff;
-		*cosOut = trig >> 0x10;
-	}
-	else if (quadrant == ANG_QUADRANT_BIT)
-	{
-		*sinOut = trig >> 0x10;
-		*cosOut = MATH_Matrix_NegLowWord(trig);
-	}
-	else if (quadrant == ANG_SIGN_BIT)
-	{
-		*sinOut = MATH_Matrix_NegLowWord(trig);
-		*cosOut = MATH_Matrix_NegLowWord(trig >> 0x10);
-	}
-	else
-	{
-		*sinOut = MATH_Matrix_NegLowWord(trig >> 0x10);
-		*cosOut = trig & 0xffff;
-	}
-}
+// NOTE: retail's ConvertRotToMatrix* call TRIG_AngleSinCos_r16r17r18_duplicate
+// (8 jal to 0x8006c430). This file used to carry a private, branch-for-branch
+// identical copy of it; the call sites now use the retail one directly.
 
 static void MATH_Matrix_LoadRotWords(u32 r0, u32 r1, u32 r2, u32 r3, u32 r4)
 {
@@ -203,7 +180,7 @@ static void MATH_Matrix_MulIfNonZero(s32 angle, u32 *r0, u32 *r1, u32 *r2, u32 *
 		return;
 	}
 
-	MATH_Matrix_TrigSinCos(angle, &sine, &cosine);
+	TRIG_AngleSinCos_r16r17r18_duplicate(angle, &sine, &cosine);
 
 	if (axis == 0)
 	{
@@ -244,13 +221,13 @@ void ConvertRotToMatrix_InverseTranspose_NoRotY(MATRIX *m, const SVec3 *rot)
 	u32 r3 = 0;
 	u32 r4 = FP_ONE;
 
-	MATH_Matrix_TrigSinCos((s32)rot->z, &sine, &cosine);
+	TRIG_AngleSinCos_r16r17r18_duplicate(rot->z, &sine, &cosine);
 	r0 = MATH_Matrix_NegHighWord(sine) | cosine;
 	r1 = sine << 0x10;
 	r2 = cosine;
 	MATH_Matrix_LoadRotWords(r0, r1, r2, r3, r4);
 
-	MATH_Matrix_MulIfNonZero((s32)rot->x, &r0, &r1, &r2, &r3, &r4, 0);
+	MATH_Matrix_MulIfNonZero(rot->x, &r0, &r1, &r2, &r3, &r4, 0);
 	MATH_Matrix_StoreWords(m, r0, r1, r2, r3, r4);
 }
 
@@ -264,7 +241,7 @@ static void MATH_Matrix_InverseTransposeBody(MATRIX *m, s32 rotX, s32 rotZ, s32 
 	u32 r3 = 0;
 	u32 r4 = FP_ONE;
 
-	MATH_Matrix_TrigSinCos(rotZ, &sine, &cosine);
+	TRIG_AngleSinCos_r16r17r18_duplicate(rotZ, &sine, &cosine);
 	r0 = MATH_Matrix_NegHighWord(sine) | cosine;
 	r1 = sine << 0x10;
 	r2 = cosine;
@@ -278,7 +255,7 @@ static void MATH_Matrix_InverseTransposeBody(MATRIX *m, s32 rotX, s32 rotZ, s32 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006c1d0-0x8006c2a4.
 void ConvertRotToMatrix_InverseTranspose(MATRIX *m, const SVec3 *rot)
 {
-	MATH_Matrix_InverseTransposeBody(m, (s32)rot->x, (s32)rot->z, (s32)rot->y);
+	MATH_Matrix_InverseTransposeBody(m, rot->x, rot->z, rot->y);
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006c2a4-0x8006c378.
@@ -292,22 +269,22 @@ void ConvertRotToMatrix(MATRIX *m, const SVec3 *rot)
 	u32 r3;
 	u32 r4;
 
-	MATH_Matrix_TrigSinCos((s32)rot->y, &sine, &cosine);
+	TRIG_AngleSinCos_r16r17r18_duplicate(rot->y, &sine, &cosine);
 	r0 = cosine;
 	r1 = sine;
 	r3 = MATH_Matrix_NegLowWord(sine);
 	r4 = cosine;
 	MATH_Matrix_LoadRotWords(r0, r1, r2, r3, r4);
 
-	MATH_Matrix_MulIfNonZero((s32)rot->x, &r0, &r1, &r2, &r3, &r4, 0);
-	MATH_Matrix_MulIfNonZero((s32)rot->z, &r0, &r1, &r2, &r3, &r4, 2);
+	MATH_Matrix_MulIfNonZero(rot->x, &r0, &r1, &r2, &r3, &r4, 0);
+	MATH_Matrix_MulIfNonZero(rot->z, &r0, &r1, &r2, &r3, &r4, 2);
 	MATH_Matrix_StoreWords(m, r0, r1, r2, r3, r4);
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006c378-0x8006c3b0.
 void ConvertRotToMatrix_Transpose(MATRIX *m, const SVec3 *rot)
 {
-	MATH_Matrix_InverseTransposeBody(m, -(s32)rot->x, -(s32)rot->z, -(s32)rot->y);
+	MATH_Matrix_InverseTransposeBody(m, -rot->x, -rot->z, -rot->y);
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8006c3b0-0x8006c430.

--- a/game/MixRNG/MixRNG.c
+++ b/game/MixRNG/MixRNG.c
@@ -18,7 +18,10 @@ int MixRNG_Particles(int param_1)
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8003eaac-0x8003eae0
-u32 MixRNG_GetValue(int param_1)
+// The result is signed: retail's only caller shifts it with sra, same as it does
+// with MixRNG_Scramble. The 0xffff is an explicit mask in retail (andi between a
+// lw/sw pair), not a narrower storage type.
+int MixRNG_GetValue(int param_1)
 {
 	return (param_1 * 0x6255 + 0x3619U) & 0xffff;
 }

--- a/game/PROC.c
+++ b/game/PROC.c
@@ -182,8 +182,11 @@ void PROC_CheckAllForDead()
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8004205c-0x8004228c.
 struct Thread *PROC_BirthWithObject(int flags, void *funcThTick, const char *name, struct Thread *relativeTh)
 {
-	int bucketID;
+	// Retail compares this with `sltiu` and loads it with `lbu`/`andi 0xff`:
+	// the bucket id is an unsigned quantity, not a signed int.
+	u32 bucketID;
 	struct JitPool *stackPool;
+	u32 stackItemSize;
 	void *stackObj;
 	struct Thread *th;
 	struct GameTracker *gGT;
@@ -205,12 +208,15 @@ struct Thread *PROC_BirthWithObject(int flags, void *funcThTick, const char *nam
 	{
 	case 0x100: // largeStack
 		stackPool = &gGT->JitPools.largeStack;
+		stackItemSize = LARGE_STACK_ITEM_SIZE;
 		break;
 	case 0x200: // mediumStack
 		stackPool = &gGT->JitPools.mediumStack;
+		stackItemSize = MEDIUM_STACK_ITEM_SIZE;
 		break;
 	default: // 0x300 = smallStack
 		stackPool = &gGT->JitPools.smallStack;
+		stackItemSize = SMALL_STACK_ITEM_SIZE;
 		break;
 	}
 
@@ -228,7 +234,9 @@ struct Thread *PROC_BirthWithObject(int flags, void *funcThTick, const char *nam
 	}
 
 	// validate size fits in pool
-	if ((u32)(flags >> 0x10) >= (stackPool->itemSize - 8))
+	// Retail extracts the size field with `srl` (logical), so the cast has to
+	// happen BEFORE the shift; `(u32)(flags >> 0x10)` would sign-extend first.
+	if (((u32)flags >> 0x10) >= (stackItemSize - 8))
 	{
 		if (stackObj != 0)
 		{
@@ -568,6 +576,10 @@ void PROC_CollideHitboxWithBucket(struct Thread *collThread, struct ScratchpadSt
 }
 
 
+// Retail keeps this pending list as a LIFO in scratchpad starting at 0x1F8000E8
+// and never bounds-checks it, so a deep enough bucket just walks over whatever
+// follows in scratchpad. Native cannot reproduce that, so the list is capped and
+// threads past the cap are dropped instead.
 enum
 {
 	THTICK_MAX_PENDING = 128
@@ -652,6 +664,12 @@ void ThTick_RunBucket(struct Thread *thread)
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80071694-0x800716ec as native-equivalent divergence.
+// Retail does NOT return to its caller: it pushes the child thread and branches
+// straight back into the ThTick_RunBucket loop, abandoning the rest of the tick.
+// Here the child push lives in ThTick_RunBucket instead, so this is a no-op and
+// control does return. That is only equivalent because every call site has this
+// as its last statement -- putting code after a ThTick_FastRET call would run in
+// native and be skipped on retail.
 void ThTick_FastRET(struct Thread *thread)
 {
 	(void)thread;

--- a/game/Particle.c
+++ b/game/Particle.c
@@ -301,7 +301,7 @@ static int Particle_OscillatorValue(struct ParticleOscillator *osc)
 		break;
 
 	case PARTICLE_OSC_MODE_SEEDED_RANDOM:
-		value = ((int)MixRNG_GetValue((s16)osc->previousValue) >> PARTICLE_OSC_RANDOM_SHIFT) - PARTICLE_OSC_WAVE_CENTER;
+		value = (MixRNG_GetValue((s16)osc->previousValue) >> PARTICLE_OSC_RANDOM_SHIFT) - PARTICLE_OSC_WAVE_CENTER;
 		break;
 
 	case PARTICLE_OSC_MODE_TIMER:

--- a/game/PickupBots.c
+++ b/game/PickupBots.c
@@ -253,7 +253,7 @@ static void PickupBots_SetBossCooldown(struct MetaDataBOSS *bossMeta)
 
 	sdata->bossWeaponCooldown = (RngDeadCoed(&sdata->advRng) & PICKUPBOTS_BOSS_COOLDOWN_RANDOM_MASK) + bossMeta->weaponCooldown +
 	                            PICKUPBOTS_BOSS_COOLDOWN_BASE_FRAMES +
-	                            ((s8)sdata->advProgress.timesLostBossRace[gGT->bossID] * PICKUPBOTS_BOSS_LOSS_COOLDOWN_STEP);
+	                            (sdata->advProgress.timesLostBossRace[gGT->bossID] * PICKUPBOTS_BOSS_LOSS_COOLDOWN_STEP);
 }
 
 static struct MetaDataBOSS *PickupBots_GetInitialBossMeta(void)

--- a/game/PlayLevel.c
+++ b/game/PlayLevel.c
@@ -344,7 +344,7 @@ void PlayLevel_UpdateLapStats(void)
 			        // AND
 
 			        // new lowest distance (max progress)
-			        ((s32)currDriver->distanceToFinish_curr < minDistance)))
+			        (currDriver->distanceToFinish_curr < minDistance)))
 			{
 				// set new min distToFinish (max progress)
 				minDistance = currDriver->distanceToFinish_curr;
@@ -406,7 +406,7 @@ void PlayLevel_UpdateLapStats(void)
 		int currRank = currDriver->driverRank;
 
 		if ((PLAYLEVEL_UNSORTED_RANK < currRank) && (PLAYLEVEL_PASS_VOICELINE_DELAY < gGT->elapsedEventTime) &&
-		    ((s8)gGT->humanPlayerPositions[driverIndex] < currRank))
+		    (gGT->humanPlayerPositions[driverIndex] < currRank))
 		{
 			int characterID = data.characterIDs[gGT->driversInRaceOrder[currRank - 1]->driverID];
 

--- a/game/RaceFlag.c
+++ b/game/RaceFlag.c
@@ -92,7 +92,10 @@ int RaceFlag_MoveModels(int frameIndex, int numFrames)
 	// on and off the screen in character selection
 
 	int angle;
-	int midpoint;
+
+	// retail keeps the halved frame count in 16 bits: the division and the
+	// truncation are fused into `sll 15` + `sra 16`.
+	s16 midpoint;
 	int result;
 
 	if (frameIndex < 0)
@@ -114,7 +117,7 @@ int RaceFlag_MoveModels(int frameIndex, int numFrames)
 		angle = (midpoint - frameIndex) * 0x400;
 
 		// 50% - sin(angle) / 2
-		result = 0x800 - MATH_Sin(angle / midpoint) / 2;
+		result = 0x800 - MATH_Sin(CTR_MipsDiv(angle, midpoint)) / 2;
 	}
 	// if more than half done
 	else
@@ -122,7 +125,7 @@ int RaceFlag_MoveModels(int frameIndex, int numFrames)
 		angle = (frameIndex - midpoint) * 0x400;
 
 		// sin(angle) / 2 + 50%
-		result = MATH_Sin(angle / midpoint) / 2 + 0x800;
+		result = MATH_Sin(CTR_MipsDiv(angle, midpoint)) / 2 + 0x800;
 	}
 	return result;
 }
@@ -240,7 +243,6 @@ s16 RaceFlag_GetCanDraw(void)
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x800440a0-0x80044290.
 u32 *RaceFlag_GetOT(void)
 {
-	s16 positionStep;
 	int position;
 	struct GameTracker *gGT = sdata->gGT;
 
@@ -282,22 +284,24 @@ u32 *RaceFlag_GetOT(void)
 			{
 				// rate of transition
 
-				position = ((u16)sdata->RaceFlag_Position >> RACE_FLAG_TRANSITION_ONSCREEN_POSITION_SHIFT) * gGT->elapsedTimeMS;
+				// retail: `sra 19` over the sign-extended halfword, an arithmetic shift
+				position = (sdata->RaceFlag_Position >> RACE_FLAG_TRANSITION_ONSCREEN_POSITION_SHIFT) * gGT->elapsedTimeMS;
 				position = position >> RACE_FLAG_TRANSITION_TIME_SHIFT;
 
-				positionStep = -(s16)position;
 				if (position < 1)
 				{
-					positionStep = -1;
+					position = 1;
 				}
 
-				sdata->RaceFlag_Position += positionStep;
+				sdata->RaceFlag_Position -= position;
 			}
 		}
 
 		// transition is finished
 		else
 		{
+			sdata->RaceFlag_Position = RACE_FLAG_POSITION_ONSCREEN;
+
 			if (sdata->RaceFlag_DrawOrder != RACE_FLAG_DRAW_ORDER_AFTER_FLAG)
 			{
 				if (sdata->RaceFlag_DrawOrder != RACE_FLAG_DRAW_ORDER_BEFORE_FLAG)
@@ -305,7 +309,8 @@ u32 *RaceFlag_GetOT(void)
 					return otDrawFirst_FarthestDepth;
 				}
 
-				sdata->RaceFlag_DrawOrder = RACE_FLAG_DRAW_ORDER_DONE;
+				// guarded by DrawOrder == BEFORE_FLAG, so this lands on DRAW_ORDER_DONE
+				sdata->RaceFlag_DrawOrder++;
 			}
 		}
 	}
@@ -315,13 +320,15 @@ u32 *RaceFlag_GetOT(void)
 	{
 		if (sdata->RaceFlag_TransitionSpeed < RACE_FLAG_TRANSITION_OFFSCREEN_SPEED_MAX)
 		{
-			sdata->RaceFlag_TransitionSpeed += (s16)((gGT->elapsedTimeMS * RACE_FLAG_TRANSITION_OFFSCREEN_ACCEL_SCALE) >> RACE_FLAG_TRANSITION_TIME_SHIFT);
+			sdata->RaceFlag_TransitionSpeed += (gGT->elapsedTimeMS * RACE_FLAG_TRANSITION_OFFSCREEN_ACCEL_SCALE) >> RACE_FLAG_TRANSITION_TIME_SHIFT;
 		}
 
 		// If transitioning "off"
 		if (sdata->RaceFlag_Position > RACE_FLAG_POSITION_OFFSCREEN_LEFT)
 		{
-			sdata->RaceFlag_Position -= (((u32)sdata->RaceFlag_TransitionSpeed >> RACE_FLAG_TRANSITION_OFFSCREEN_POSITION_SHIFT) * gGT->elapsedTimeMS) >>
+			// retail: `sll 16` + `sra 18` over the speed, then `mult` and `sra 5`; every
+			// shift here is arithmetic
+			sdata->RaceFlag_Position -= ((sdata->RaceFlag_TransitionSpeed >> RACE_FLAG_TRANSITION_OFFSCREEN_POSITION_SHIFT) * gGT->elapsedTimeMS) >>
 			                            RACE_FLAG_TRANSITION_TIME_SHIFT;
 		}
 
@@ -351,7 +358,11 @@ void RaceFlag_DrawLoadingString(void)
 	struct GameTracker *gGT = sdata->gGT;
 	int loadingTextBytes;
 	int letterAnimFrame;
-	int letterX;
+
+	// retail keeps the per-letter X in 16 bits: it re-normalizes with `sll 16` +
+	// `sra 16` before every use
+	s16 letterX;
+	int letterWidth;
 	int glyphByteCount;
 	int textByteIndex;
 	char *loadingText;
@@ -372,7 +383,9 @@ void RaceFlag_DrawLoadingString(void)
 	// get length of "LOADING..." string
 	loadingTextBytes = strlen(loadingText);
 
-	int textWidth = DecalFont_GetLineWidth(loadingText, RACE_FLAG_LOADING_FONT_SIZE);
+	// retail truncates the measured width to 16 bits and halves it with a signed
+	// division, not with a shift (`sll 16` / `sra 16` / `srl 31` / `sra 1`)
+	s16 textWidth = DecalFont_GetLineWidth(loadingText, RACE_FLAG_LOADING_FONT_SIZE);
 
 	// loop counter
 	textByteIndex = 0;
@@ -380,7 +393,7 @@ void RaceFlag_DrawLoadingString(void)
 	// if game is not loading
 	if (sdata->Loading.stage == LOAD_IDLE)
 	{
-		if (RACE_FLAG_LOADING_IDLE_SLIDE_LIMIT < (int)sdata->RaceFlag_Transition)
+		if (RACE_FLAG_LOADING_IDLE_SLIDE_LIMIT < sdata->RaceFlag_Transition)
 		{
 			sdata->RaceFlag_Transition -= RACE_FLAG_LOADING_IDLE_SLIDE_STEP;
 		}
@@ -390,7 +403,8 @@ void RaceFlag_DrawLoadingString(void)
 		sdata->RaceFlag_Transition = 0;
 	}
 
-	drawX = (sdata->RaceFlag_Transition & 0xffff) - (textWidth >> 1);
+	// the mask models retail's `lhu` over the low half of the 32-bit field
+	drawX = (sdata->RaceFlag_Transition & 0xffff) - (textWidth / 2);
 
 	letterAnimFrame = sdata->RaceFlag_LoadingTextAnimFrame;
 
@@ -441,15 +455,15 @@ void RaceFlag_DrawLoadingString(void)
 
 				glyphByteCount = 2;
 			}
-			if ((s16)letterX != RACE_FLAG_LOADING_OFFSCREEN_X)
+			if (letterX != RACE_FLAG_LOADING_OFFSCREEN_X)
 			{
 				DecalFont_DrawLineStrlen((char *)glyph, glyphByteCount, (s16)(drawX + letterX), RACE_FLAG_LOADING_Y, RACE_FLAG_LOADING_FONT_SIZE,
 				                         RACE_FLAG_LOADING_TEXT_FLAGS);
 			}
 
-			letterX = DecalFont_GetLineWidthStrlen((char *)glyph, glyphByteCount, RACE_FLAG_LOADING_FONT_SIZE);
+			letterWidth = DecalFont_GetLineWidthStrlen((char *)glyph, glyphByteCount, RACE_FLAG_LOADING_FONT_SIZE);
 
-			drawX = drawX + letterX;
+			drawX = drawX + letterWidth;
 			nextLetterStartX = nextLetterStartX + RACE_FLAG_LOADING_NEXT_LETTER_START_X;
 
 			// increment loop counter
@@ -576,7 +590,9 @@ SKIP_LOADING_TEXT:
 	gte_SetGeomOffset(0x100, 0x78);
 	gte_SetGeomScreen(0x100);
 
-	p = (POLY_G4 *)gGT->backBuffer->primMem.cursor;
+	// retail allocates one primitive at a time inside the loop, and leaves the
+	// pointer at NULL until the first allocation succeeds
+	p = nullptr;
 
 	scratch = CTR_SCRATCHPAD_PTR(struct RaceFlagScratch, 0);
 
@@ -599,26 +615,37 @@ SKIP_LOADING_TEXT:
 		local[4] = data.checkerFlagVariables[4];
 
 		// === Step 1 ===
+		// only this first column writes the globals back; the remaining 34 run on
+		// the local copies, exactly like retail (which spills them to the stack)
 		int stepRate = gGT->elapsedTimeMS;
 		local[4] += local[3] * stepRate;
-		var1 = (int)local[4] >> 5;
+		data.checkerFlagVariables[4] = local[4];
+		var1 = local[4] >> 5;
 
 		// === Step 2 ===
 		if (0xfff < var1)
 		{
 			// reset counter
 			local[4] &= 0x1ffff;
-			var1 = (int)local[4] >> 5;
+			data.checkerFlagVariables[4] = local[4];
+			var1 = local[4] >> 5;
 
 			local[0] += 0x200;
-			local[2] += 200;
+			data.checkerFlagVariables[0] = local[0];
 
 			int sin0 = RaceFlag_Sin(local[0]) + 0xfff;
-			int sin2 = RaceFlag_Sin(local[2]) + 0xfff;
 
 			// reset based on trig
 			local[1] = (sin0 * 0x20 >> 0xd) + 0x96;
+			data.checkerFlagVariables[1] = local[1];
+
+			local[2] += 200;
+			data.checkerFlagVariables[2] = local[2];
+
+			int sin2 = RaceFlag_Sin(local[2]) + 0xfff;
+
 			local[3] = (sin2 * 0x40 >> 0xd) + 0xb4;
+			data.checkerFlagVariables[3] = local[3];
 		}
 
 		// === Step 3 ===
@@ -636,12 +663,6 @@ SKIP_LOADING_TEXT:
 		pos[2].vy = 0xfd2e;
 
 		// === Step 6 ===
-		data.checkerFlagVariables[0] = local[0];
-		data.checkerFlagVariables[1] = local[1];
-		data.checkerFlagVariables[2] = local[2];
-		data.checkerFlagVariables[3] = local[3];
-		data.checkerFlagVariables[4] = local[4];
-
 		time = sdata->RaceFlag_ElapsedTime >> 5;
 		var1 = time;
 
@@ -663,7 +684,7 @@ SKIP_LOADING_TEXT:
 				var1 += 300;
 
 				// change all vector posZ
-				vect->vz = (s16)var2 + (s16)(var3 * 0x20 >> 0xd);
+				vect->vz = var2 + (var3 * 0x20 >> 0xd);
 			}
 
 			CTR_GteLoadSV3WithPad(&pos[0], &pos[1], &pos[2]);
@@ -691,14 +712,14 @@ SKIP_LOADING_TEXT:
 		// === Step 1 ===
 		int stepRate = 0x40;
 		local[4] += local[3] * stepRate;
-		var1 = (int)local[4] >> 5;
+		var1 = local[4] >> 5;
 
 		// === Step 2 ===
 		if (0xfff < var1)
 		{
 			// reset counter
 			local[4] &= 0x1ffff;
-			var1 = (int)local[4] >> 5;
+			var1 = local[4] >> 5;
 
 			local[0] += 0x200;
 			local[2] += 200;
@@ -745,7 +766,7 @@ SKIP_LOADING_TEXT:
 				var1 += 300;
 
 				// change all vector posZ
-				vect->vz = (s16)var2 + (s16)(var3 * 0x20 >> 0xd);
+				vect->vz = var2 + (var3 * 0x20 >> 0xd);
 			}
 
 			CTR_GteLoadSV3WithPad(&pos[0], &pos[1], &pos[2]);
@@ -770,16 +791,35 @@ SKIP_LOADING_TEXT:
 				if (((read0 & read1 & write0 & write1 & screenlimit) == 0) &&
 				    (((dimensions - read0) & (dimensions - read1) & (dimensions - write0) & (dimensions - write1) & screenlimit) == 0))
 				{
+					struct PrimMem *primMem = &gGT->backBuffer->primMem;
+
+					// one primitive per quad, guard-checked. When the guard is hit retail
+					// keeps writing over the last primitive it managed to allocate.
+					if (primMem->cursor <= primMem->guardEnd)
+					{
+						p = (POLY_G4 *)primMem->cursor;
+						primMem->cursor = (void *)((char *)primMem->cursor + sizeof(POLY_G4));
+					}
+
+					if (p == nullptr)
+					{
+						return;
+					}
+
 					// TRUE for gray, FALSE for white
 					u8 boolDark = ((((column >> 2) + (i >> 2)) & 1U) != 0);
 
+					// retail builds the whole colour word (`c | c << 8 | c << 16`) and stores
+					// it twice, so the code/pad byte of every colour word ends up zeroed
 					u8 colorR = RaceFlag_CalculateBrightness(lightR, boolDark);
-					setRGB0(p, colorR, colorR, colorR);
-					CTR_WriteU32LE(&p->r2, CTR_ReadU32LE(&p->r0));
+					u32 packedR = CtrGpu_PackColorCode((u32)colorR * 0x10101u, 0);
+					CTR_WriteU32LE(&p->r0, packedR);
+					CTR_WriteU32LE(&p->r2, packedR);
 
 					u8 colorL = RaceFlag_CalculateBrightness(lightL, boolDark);
-					setRGB1(p, colorL, colorL, colorL);
-					CTR_WriteU32LE(&p->r3, CTR_ReadU32LE(&p->r1));
+					u32 packedL = CtrGpu_PackColorCode((u32)colorL * 0x10101u, 0);
+					CTR_WriteU32LE(&p->r1, packedL);
+					CTR_WriteU32LE(&p->r3, packedL);
 
 					// positions
 					CtrGpu_WritePackedXY(&p->x0, read0);
@@ -794,8 +834,6 @@ SKIP_LOADING_TEXT:
 					// addPrim(ot, p); works but uses more instructions.
 					p->tag = CtrGpu_PackOTTag(*ot, 0x8000000);
 					*ot = CtrGpu_PrimToOTLink24(p);
-
-					p++;
 				}
 			}
 		}
@@ -803,6 +841,6 @@ SKIP_LOADING_TEXT:
 		lightR = lightL;
 	}
 
-	gGT->backBuffer->primMem.cursor = p;
 	sdata->RaceFlag_ElapsedTime += gGT->elapsedTimeMS * 100;
 }
+

--- a/game/Timer.c
+++ b/game/Timer.c
@@ -35,14 +35,17 @@ int Timer_GetTime_Total()
 {
 	s32 rcntTotal = sdata->rcntTotalUnits;
 	s32 rcnt = GetRCnt(TIMER_RCNT);
-	s32 sysClock = rcntTotal + rcnt;
+	s32 sysClock = CTR_MipsAddLo(rcntTotal, rcnt);
 
 	if (rcnt < TIMER_RCNT_LOW_RECHECK_THRESHOLD)
 	{
-		sysClock = sdata->rcntTotalUnits + rcnt;
+		sysClock = CTR_MipsAddLo(sdata->rcntTotalUnits, rcnt);
 	}
 
-	return (sysClock * TIMER_MILLISECONDS_PER_SECOND) / TIMER_RCNT_UNITS_PER_SECOND;
+	// The 32-bit product is expected to wrap: the counter passes 0x7fffffff after
+	// roughly two minutes of uptime and Timer_GetTime_Elapsed compensates with
+	// TIMER_WRAP_MILLISECONDS, so the wraparound is load-bearing rather than a bug.
+	return CTR_MipsDiv(CTR_MipsMulLo(sysClock, TIMER_MILLISECONDS_PER_SECOND), TIMER_RCNT_UNITS_PER_SECOND);
 }
 
 // Usage: elapsed(frameStart, &frameStart)
@@ -58,11 +61,11 @@ int Timer_GetTime_Elapsed(int oldVal, int *retVal)
 		*retVal = newVal;
 	}
 
-	// impossible?
+	// Reached every time the wrapping product in Timer_GetTime_Total rolls over.
 	if (newVal < oldVal)
 	{
-		newVal += TIMER_WRAP_MILLISECONDS;
+		newVal = CTR_MipsAddLo(newVal, TIMER_WRAP_MILLISECONDS);
 	}
 
-	return newVal - oldVal;
+	return CTR_MipsSubLo(newVal, oldVal);
 }

--- a/game/UI/UI_Map.c
+++ b/game/UI/UI_Map.c
@@ -426,10 +426,10 @@ void UI_Map_DrawTracking(struct UIMap *map, struct Thread *bucket)
 		// == only draw target if target exists ==
 
 		// flicker
-		targetColor = CRASH_BLUE;
+		targetColor = WHITE;
 		if ((sdata->gGT->timer & 1) != 0)
 		{
-			targetColor = CORTEX_RED;
+			targetColor = RED;
 		}
 
 		UI_Map_DrawRawIcon(map, &d->instSelf->matrix.t[0], UI_MAP_WARPBALL_TARGET_ICON, targetColor, 0, UI_MAP_ICON_SCALE);

--- a/game/UI/UI_RenderFrame.c
+++ b/game/UI/UI_RenderFrame.c
@@ -12,6 +12,7 @@ void UI_RenderFrame_Racing()
 	int partTimeVariable1;
 	u32 *ptrColor;
 	char *pbVar6;
+	u8 *spawnOrderPtr;
 	int i;
 	struct PushBuffer *pb;
 	u32 partTimeVariable5;
@@ -65,10 +66,10 @@ void UI_RenderFrame_Racing()
 		{
 			data.rankIconsTransitionTimer[i] = 0;
 
-			pbVar6 = &sdata->kartSpawnOrderArray[i];
+			spawnOrderPtr = &sdata->kartSpawnOrderArray[i];
 
-			data.rankIconsCurr[i] = (u16)*pbVar6;
-			data.rankIconsDesired[i] = (u16)*pbVar6;
+			data.rankIconsCurr[i] = (u16)*spawnOrderPtr;
+			data.rankIconsDesired[i] = (u16)*spawnOrderPtr;
 		}
 	}
 

--- a/game/Vehicle/VehCalc.c
+++ b/game/Vehicle/VehCalc.c
@@ -22,9 +22,13 @@ int VehCalc_InterpBySpeed(int val, int speed, int desired)
 		{
 			return desired;
 		}
+
+		return val;
 	}
 
-	else
+	// Retail returns `val` untouched when it already equals `desired`; only the
+	// strictly-less case adds `speed`.
+	if (val < desired)
 	{
 		val = CTR_MipsAddLo(val, speed);
 

--- a/game/Vehicle/VehEmitter.c
+++ b/game/Vehicle/VehEmitter.c
@@ -5,6 +5,8 @@ enum
 	VEH_EMITTER_AXIS_COUNT = 3,
 	VEH_EMITTER_EXHAUST_ICON_LOW = 1,
 	VEH_EMITTER_EXHAUST_ICON_WATER = 7,
+	VEH_EMITTER_EXHAUST_MED_LOD_PLAYERS = 2,
+	VEH_EMITTER_EXHAUST_LOW_LOD_MIN_PLAYERS = 3,
 	VEH_EMITTER_EXHAUST_WATER_Y_LIMIT = FP8_ONE,
 	VEH_EMITTER_EXHAUST_VEL_Y = 0x400,
 	VEH_EMITTER_EXHAUST_VEL_Z = -0x400,
@@ -70,7 +72,6 @@ enum
 	VEH_EMITTER_WALL_SPARK_Y = 0x0a00,
 	VEH_EMITTER_WALL_SPARK_REVERSE_Z = -0x1400,
 	VEH_EMITTER_WALL_SPARK_FORWARD_Z = 0x2800,
-	VEH_EMITTER_WALL_SPARK_SCRATCH_HALF_COUNT = 6,
 	VEH_EMITTER_ALPHA_FULL = 0x1000,
 	VEH_EMITTER_JOG_GROUND = 0x27,
 	VEH_EMITTER_JOG_WOBBLE_ALT = 0xf0,
@@ -85,6 +86,8 @@ enum
 CTR_STATIC_ASSERT(VEH_EMITTER_AXIS_COUNT == 3);
 CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_ICON_LOW == 1);
 CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_ICON_WATER == 7);
+CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_MED_LOD_PLAYERS == 2);
+CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_LOW_LOD_MIN_PLAYERS == 3);
 CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_WATER_Y_LIMIT == 0x100);
 CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_VEL_Y == 0x400);
 CTR_STATIC_ASSERT(VEH_EMITTER_EXHAUST_VEL_Z == -0x400);
@@ -150,7 +153,6 @@ CTR_STATIC_ASSERT(VEH_EMITTER_WALL_SPARK_RIGHT_X == 0x2200);
 CTR_STATIC_ASSERT(VEH_EMITTER_WALL_SPARK_Y == 0x0a00);
 CTR_STATIC_ASSERT(VEH_EMITTER_WALL_SPARK_REVERSE_Z == -0x1400);
 CTR_STATIC_ASSERT(VEH_EMITTER_WALL_SPARK_FORWARD_Z == 0x2800);
-CTR_STATIC_ASSERT(VEH_EMITTER_WALL_SPARK_SCRATCH_HALF_COUNT == 6);
 CTR_STATIC_ASSERT(VEH_EMITTER_ALPHA_FULL == 0x1000);
 CTR_STATIC_ASSERT(VEH_EMITTER_JOG_GROUND == 0x27);
 CTR_STATIC_ASSERT(VEH_EMITTER_JOG_WOBBLE_ALT == 0xf0);
@@ -177,28 +179,35 @@ struct Particle *VehEmitter_Exhaust(struct Driver *d, VECTOR *exhaustPos, VECTOR
 		return 0;
 	}
 
-	// low LOD exhaust (4p or ai car)
 	int exhaustType = VEH_EMITTER_EXHAUST_ICON_LOW;
-	struct ParticleEmitter *emSet = &data.emSet_Exhaust_Low[0];
+	struct ParticleEmitter *emSet;
 
 	u8 numPlyr = gGT->numPlyrCurrGame;
 
-	// equivalent of (d->driverID < numPlyr),
+	// Retail picks the LOD by falling through to the high set, so every player count below 2
+	// (including 0) lands on the high set before the robot-car override below.
+	if (numPlyr >= VEH_EMITTER_EXHAUST_LOW_LOD_MIN_PLAYERS)
+	{
+		// 3P/4P mode, low LOD exhaust
+		emSet = &data.emSet_Exhaust_Low[0];
+	}
+	else if (numPlyr == VEH_EMITTER_EXHAUST_MED_LOD_PLAYERS)
+	{
+		// 2P mode, med LOD exhaust
+		emSet = &data.emSet_Exhaust_Med[0];
+	}
+	else
+	{
+		// 1P mode, high LOD exhaust
+		emSet = &data.emSet_Exhaust_High[0];
+	}
+
+	// low LOD exhaust for ai cars. equivalent of (d->driverID >= numPlyr),
 	// because modelIndex is not set to DYNAMIC_ROBOT_CAR
 	// for human players after BOTS_Driver_Convert is called
-	if (dInst->thread->modelIndex != DYNAMIC_ROBOT_CAR)
+	if (dInst->thread->modelIndex == DYNAMIC_ROBOT_CAR)
 	{
-		switch (numPlyr)
-		{
-		case 1:
-			// 1P mode, high LOD exhaust
-			emSet = &data.emSet_Exhaust_High[0];
-			break;
-		case 2:
-			// 2P mode, med LOD exhaust
-			emSet = &data.emSet_Exhaust_Med[0];
-			break;
-		}
+		emSet = &data.emSet_Exhaust_Low[0];
 	}
 
 	if (((dInst->flags & SPLIT_LINE) != 0) && ((exhaustPos->vy - exhaustVel->vy) + d->posCurr.y < VEH_EMITTER_EXHAUST_WATER_Y_LIMIT))
@@ -421,16 +430,26 @@ void VehEmitter_Sparks_Wall(struct Driver *d, struct ParticleEmitter *emSet)
 	}
 
 	union VehEmitterWallScratch *scratch = CTR_SCRATCHPAD_PTR(union VehEmitterWallScratch, 0);
-	s32 *tireLeftOutWord = &scratch->word[0];
-	s32 *tireRightOutWord = &scratch->word[3];
+	s32 *tireLeftInWord = &scratch->word[0];
+	s32 *tireRightInWord = &scratch->word[3];
 	s16 *tireLeftOutHalf = &scratch->half[0];
 	s16 *tireRightOutHalf = &scratch->half[3];
+	// tireRightInWord starts at half[6], not at half[3]: half[3] is where the packed right-tire
+	// result lands below, where it doubles as rows 4-6 of the 3x2 light matrix. Reading the
+	// right-tire GTE input from half[3] would feed back the tail of the left-tire result.
+	s16 *tireLeftInHalf = &scratch->half[0];
+	s16 *tireRightInHalf = &scratch->half[6];
 	s16 *distIn4 = &scratch->half[6];
-	s32 *distOut4 = &scratch->word[3];
+	// Retail keeps both untruncated rotated triplets in registers across the packing below and
+	// adds those to the particle start position; only the packed copies feed the light matrix.
+	s32 tireLeftRotated[VEH_EMITTER_AXIS_COUNT];
+	s32 tireRightRotated[VEH_EMITTER_AXIS_COUNT];
+	s32 *tireRotated = tireLeftRotated;
+	s32 distOut4[VEH_EMITTER_AXIS_COUNT];
 
 	// s16[3] array
-	tireLeftOutWord[0] = (s32)CTR_PackS16Pair(VEH_EMITTER_WALL_SPARK_LEFT_X, VEH_EMITTER_WALL_SPARK_Y);
-	tireRightOutWord[0] = (s32)CTR_PackS16Pair(VEH_EMITTER_WALL_SPARK_RIGHT_X, VEH_EMITTER_WALL_SPARK_Y);
+	tireLeftInWord[0] = (s32)CTR_PackS16Pair(VEH_EMITTER_WALL_SPARK_LEFT_X, VEH_EMITTER_WALL_SPARK_Y);
+	tireRightInWord[0] = (s32)CTR_PackS16Pair(VEH_EMITTER_WALL_SPARK_RIGHT_X, VEH_EMITTER_WALL_SPARK_Y);
 
 	int valZ = VEH_EMITTER_WALL_SPARK_REVERSE_Z;
 	if (d->speedApprox > 0)
@@ -439,22 +458,23 @@ void VehEmitter_Sparks_Wall(struct Driver *d, struct ParticleEmitter *emSet)
 	}
 
 	// s16[3] array
-	tireLeftOutWord[1] = valZ;
-	tireRightOutWord[1] = valZ;
+	tireLeftInWord[1] = valZ;
+	tireRightInWord[1] = valZ;
 
-	CTR_GteLoadS16TripletV0(tireLeftOutHalf);
+	CTR_GteLoadS16TripletV0(tireLeftInHalf);
 	gte_rtv0();
-	CTR_GteStoreMAC(&tireLeftOutWord[0]);
+	CTR_GteStoreMAC(tireLeftRotated);
 
-	CTR_GteLoadS16TripletV0(tireRightOutHalf);
+	CTR_GteLoadS16TripletV0(tireRightInHalf);
 	gte_rtv0();
-	CTR_GteStoreMAC(&tireRightOutWord[0]);
+	CTR_GteStoreMAC(tireRightRotated);
 
 	// this compresses TireLeft and TireRight from int to s16,
 	// which then doubles in usage as a matrix (3x2)
-	for (int i = 0; i < VEH_EMITTER_WALL_SPARK_SCRATCH_HALF_COUNT; i++)
+	for (int i = 0; i < VEH_EMITTER_AXIS_COUNT; i++)
 	{
-		tireLeftOutHalf[i] = (u16)scratch->word[i];
+		tireLeftOutHalf[i] = (s16)tireLeftRotated[i];
+		tireRightOutHalf[i] = (s16)tireRightRotated[i];
 	}
 
 #ifdef CTR_NATIVE
@@ -490,10 +510,10 @@ void VehEmitter_Sparks_Wall(struct Driver *d, struct ParticleEmitter *emSet)
 
 	CTR_GteLoadS16TripletV0(&distIn4[0]);
 	gte_llv0();
-	CTR_GteStoreMAC(&distOut4[0]);
+	CTR_GteStoreMAC(distOut4);
 	if (distOut4[0] < distOut4[1])
 	{
-		tireLeftOutHalf = tireRightOutHalf;
+		tireRotated = tireRightRotated;
 	}
 
 	// Create instance in particle pool
@@ -506,14 +526,14 @@ void VehEmitter_Sparks_Wall(struct Driver *d, struct ParticleEmitter *emSet)
 
 	for (int i = 0; i < VEH_EMITTER_AXIS_COUNT; i++)
 	{
-		p->axis[i].startVal += tireLeftOutHalf[i];
+		p->axis[i].startVal += tireRotated[i];
 		distIn4[i] = p->axis[i].velocity;
 	}
 
 	// dist4 now determines velocity
 	CTR_GteLoadS16TripletV0(&distIn4[0]);
 	gte_rtv0();
-	CTR_GteStoreMAC(&distOut4[0]);
+	CTR_GteStoreMAC(distOut4);
 
 	p->axis[0].velocity = (s16)distOut4[0];
 	p->axis[1].velocity = (s16)distOut4[1];

--- a/game/Vehicle/VehFire.c
+++ b/game/Vehicle/VehFire.c
@@ -117,7 +117,6 @@ void VehFire_Increment(struct Driver *driver, int reserves, u32 type, int fireLe
 	s8 count;
 
 	int newFireSpeedCap;
-	int newFireSize;
 	int oldOTT;
 
 	u32 addFlags;
@@ -379,12 +378,13 @@ void VehFire_Increment(struct Driver *driver, int reserves, u32 type, int fireLe
 		if (turboObj != 0)
 		{
 			// modify, cap, and save the size of the fire
-			newFireSize = CTR_MipsAddLo(CTR_MipsSra(fireLevel, VEH_FIRE_SIZE_SHIFT), VEH_FIRE_SIZE_BASE);
-			if (newFireSize > VEH_FIRE_SIZE_MAX)
+			// Retail stores the size first and caps the stored s16, not the
+			// 32-bit intermediate, so the truncation happens before the compare.
+			turboObj->fireSize = (s16)CTR_MipsAddLo(CTR_MipsSra(fireLevel, VEH_FIRE_SIZE_SHIFT), VEH_FIRE_SIZE_BASE);
+			if (turboObj->fireSize > VEH_FIRE_SIZE_MAX)
 			{
-				newFireSize = VEH_FIRE_SIZE_MAX;
+				turboObj->fireSize = VEH_FIRE_SIZE_MAX;
 			}
-			turboObj->fireSize = (s16)newFireSize;
 		}
 	}
 

--- a/game/Vehicle/VehGroundShadow.c
+++ b/game/Vehicle/VehGroundShadow.c
@@ -27,7 +27,7 @@ enum
 	VEH_GROUND_SHADOW_LOCAL_SCALE_SHIFT = 6,
 
 	VEH_GROUND_SHADOW_PRIM_GUARD_WORDS = 0x140,
-	VEH_GROUND_SHADOW_GTE_SCREEN_SHIFT = 15,
+	VEH_GROUND_SHADOW_GEOM_OFFSET_SHIFT = 1,
 	VEH_GROUND_SHADOW_LARGE_GEOM_SCREEN_THRESHOLD = 0x100,
 	VEH_GROUND_SHADOW_CAMERA_DELTA_SCALE = 4,
 	VEH_GROUND_SHADOW_SMALL_SCREEN_MAX_EXCLUSIVE = 0x1771,
@@ -405,9 +405,10 @@ void VehGroundShadow_Main(void)
 		u32 *otBase = pb->ptrOT;
 		int isLargeGeomScreen;
 
-		CTC2((u32)(s32)pb->rect.w << VEH_GROUND_SHADOW_GTE_SCREEN_SHIFT, 24);
-		CTC2((u32)(s32)pb->rect.h << VEH_GROUND_SHADOW_GTE_SCREEN_SHIFT, 25);
-		CTC2((u32)pb->distanceToScreen_PREV, 26);
+		// retail halves the rect first and only then shifts into 16.16, so odd extents keep
+		// truncating instead of landing half a pixel off
+		gte_SetGeomOffset(pb->rect.w >> VEH_GROUND_SHADOW_GEOM_OFFSET_SHIFT, pb->rect.h >> VEH_GROUND_SHADOW_GEOM_OFFSET_SHIFT);
+		gte_SetGeomScreen(pb->distanceToScreen_PREV);
 		VehGroundShadow_LoadGteRotMatrix(&pb->matrix_ViewProj);
 		isLargeGeomScreen = pb->distanceToScreen_PREV > VEH_GROUND_SHADOW_LARGE_GEOM_SCREEN_THRESHOLD;
 

--- a/game/Vehicle/VehGroundSkids.c
+++ b/game/Vehicle/VehGroundSkids.c
@@ -225,7 +225,8 @@ static void VehGroundSkids_TryEmitSegment(struct VehGroundSkidsScratch *scratch,
 		return;
 	}
 
-	scratch->segmentFlagsLow = mark->flags;
+	// retail stores the whole word, so the upper bytes are cleared rather than left stale
+	scratch->segmentFlags = mark->flags;
 	int depth = (currDepth[pointIndex] >> VEH_GROUND_SKIDS_DEPTH_SHIFT) + (mark->color << VEH_GROUND_SKIDS_OT_DEPTH_SHIFT);
 	VehGroundSkids_Subset1(&currXY[pointIndex], &prevXY[pointIndex], depth, scratch);
 }

--- a/game/Vehicle/VehLap.c
+++ b/game/Vehicle/VehLap.c
@@ -81,7 +81,7 @@ void VehLap_UpdateProgress(struct Driver *driver)
 
 	driver->distanceToFinish_curr = progress;
 	// NOTE(aalhendi): Retail uses signed div/mfhi for this remainder.
-	driver->distanceToFinish_curr = progress % trackLength;
+	driver->distanceToFinish_curr = CTR_MipsRem(progress, trackLength);
 
 	if (wrongWayTest < VEH_LAP_WRONG_WAY_DOT_LIMIT)
 	{

--- a/game/Vehicle/VehPhysCrash.c
+++ b/game/Vehicle/VehPhysCrash.c
@@ -351,7 +351,9 @@ static void VehPhysCrash_PlayHumanFeedback(struct Thread *selfThread, struct Thr
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x8005d404-0x8005e104
 void VehPhysCrash_AnyTwoCars(struct Thread *thread, struct DriverCollisionSearch *search, Vec3 *selfVel)
 {
-	int distance = VehCalc_FastSqrt(search->bucket.bestDistSq, 0);
+	// Retail calls MATH_FastSqrt here (0x8005d43c), not VehCalc_FastSqrt. Both
+	// return floor(sqrt(n)), but retail takes prevalence.
+	int distance = MATH_FastSqrt(search->bucket.bestDistSq, 0);
 	const SVec3 *dist = &search->bucket.dist;
 	SVec3 *hitDir = &search->hitDir;
 

--- a/game/Vehicle/VehPhysForce.c
+++ b/game/Vehicle/VehPhysForce.c
@@ -1100,18 +1100,13 @@ void VehPhysForce_TranslateMatrix(struct Thread *thread, struct Driver *driver)
 	VehPhysForce_TranslateMatrix_UpdateWake(inst, driver);
 }
 
+// Retail feeds LZCS and reads LZCR unconditionally, before it
+// branches on `denom`. Callers observe that CP2 state, so use the GTE here
 static int VehPhysForce_CountLeadingSignBits(s32 value)
 {
-	u32 bits = (u32)value;
-	u32 sign = bits >> 31;
-	int count = 0;
+	MTC2((u32)value, 30);
 
-	while (count < 32 && (((bits >> (31 - count)) & 1) == sign))
-	{
-		count++;
-	}
-
-	return count;
+	return (int)MFC2(31);
 }
 
 static struct TrigPair VehPhysForce_TrigAngleSinCos(int angle)
@@ -1170,6 +1165,8 @@ void VehPhysForce_RotAxisAngle(MATRIX *m, s16 *normVec, s16 angle)
 	m->m[1][1] = (s16)normalY;
 	m->m[2][1] = (s16)normalZ;
 
+	int leadingSignBits = VehPhysForce_CountLeadingSignBits(denom);
+
 	if (denom == 0)
 	{
 		s32 dot = CTR_MipsAddLo(CTR_MipsMulLo(trig.sin, normalX), CTR_MipsMulLo(trig.cos, normalZ));
@@ -1183,7 +1180,7 @@ void VehPhysForce_RotAxisAngle(MATRIX *m, s16 *normVec, s16 angle)
 	}
 	else
 	{
-		int shift = CTR_MipsSubLo(0x14, VehPhysForce_CountLeadingSignBits(denom));
+		int shift = CTR_MipsSubLo(0x14, leadingSignBits);
 		s32 sinRemainder;
 		s32 cosRemainder;
 		s32 divX;

--- a/game/Vehicle/VehPhysGeneral.c
+++ b/game/Vehicle/VehPhysGeneral.c
@@ -1137,7 +1137,11 @@ void VehPhysGeneral_SetHeldItem(struct Driver *driver)
 	case ITEMSET_Race4:
 	case ITEMSET_BattleDefault:
 	case ITEMSET_BossRace:
-		driver->heldItemID = itemSetWeaponTables[itemSet][(rng * itemSetWeaponCounts[itemSet]) / ITEMSET_RNG_BUCKET_COUNT];
+		// Retail divides this one WITHOUT sign (multu + srl 3/6, one inlined
+		// weapon count per case), and the battle-custom case below WITH sign
+		// (mult + sra + correction, since numWeapons is an int). rng is always
+		// in [0, 199] so both give the same index, but retail takes prevalence.
+		driver->heldItemID = itemSetWeaponTables[itemSet][((u32)rng * itemSetWeaponCounts[itemSet]) / ITEMSET_RNG_BUCKET_COUNT];
 		break;
 
 	// uses int array instead of char,

--- a/game/Vehicle/VehPhysProc.c
+++ b/game/Vehicle/VehPhysProc.c
@@ -24,7 +24,9 @@ enum
 	VEH_PHYS_PROC_TEN_WUMPA_COUNT = 10,
 	VEH_PHYS_PROC_HAZARD_MOVING_SPEED_MIN = 0x100,
 	VEH_PHYS_PROC_HAZARD_LOW_SPEED_THRESHOLD = 0x101,
-	VEH_PHYS_PROC_HAZARD_TIMER_EVEN_MASK = 0xfffe,
+	// Retail materializes this as `addiu v0, zero, -2` (0xfffffffe), so the mask
+	// must stay 32-bit signed or the sign of hazardTimer is lost.
+	VEH_PHYS_PROC_HAZARD_TIMER_EVEN_MASK = ~1,
 	VEH_PHYS_PROC_CLOCK_WADDLE_TIMER_SHIFT = 6,
 	VEH_PHYS_PROC_CLOCK_WADDLE_TIMER_MAX = 0x40,
 	VEH_PHYS_PROC_CLOCK_WADDLE_TRIG_SHIFT = 4,
@@ -116,7 +118,7 @@ CTR_STATIC_ASSERT(VEH_PHYS_PROC_DISTANCE_SPEED_SHIFT == 8);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_TEN_WUMPA_COUNT == 10);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_HAZARD_MOVING_SPEED_MIN == 0x100);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_HAZARD_LOW_SPEED_THRESHOLD == 0x101);
-CTR_STATIC_ASSERT(VEH_PHYS_PROC_HAZARD_TIMER_EVEN_MASK == 0xfffe);
+CTR_STATIC_ASSERT(VEH_PHYS_PROC_HAZARD_TIMER_EVEN_MASK == -2);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_CLOCK_WADDLE_TIMER_SHIFT == 6);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_CLOCK_WADDLE_TIMER_MAX == 0x40);
 CTR_STATIC_ASSERT(VEH_PHYS_PROC_CLOCK_WADDLE_TRIG_SHIFT == 4);
@@ -306,23 +308,6 @@ void VehPhysProc_Driving_PhysLinear(struct Thread *thread, struct Driver *driver
 
 	VehPhysProc_Driving_DecrementTimer(&driver->clockReceive, msPerFrame);
 	VehPhysProc_Driving_DecrementTimer(&driver->accelTapWindowTimer, msPerFrame);
-
-	// If invisible, without Permanent Invisibility cheat,
-	// dont remove invisibleTimer check, or an invalid
-	// instFlagsBackup overwrites instFlags
-	if ((driver->invisibleTimer != 0) && ((gameMode2 & CHEAT_INVISIBLE) == 0))
-	{
-		driver->invisibleTimer = CTR_MipsSubLo(driver->invisibleTimer, msPerFrame);
-
-		// if newly visible
-		if (driver->invisibleTimer <= 0)
-		{
-			driver->invisibleTimer = 0;
-			driver->instSelf->flags = driver->instFlagsBackup;
-			driver->instSelf->alphaScale = 0;
-			OtherFX_Play(VEH_PHYS_PROC_INVISIBLE_REAPPEAR_FX, 1);
-		}
-	}
 
 	if (0 < driver->jump_TenBuffer)
 	{
@@ -549,6 +534,23 @@ void VehPhysProc_Driving_PhysLinear(struct Thread *thread, struct Driver *driver
 		if (driver->invincibleTimer < 0)
 		{
 			driver->invincibleTimer = 0;
+		}
+	}
+
+	// If invisible, without Permanent Invisibility cheat,
+	// dont remove invisibleTimer check, or an invalid
+	// instFlagsBackup overwrites instFlags
+	if ((driver->invisibleTimer != 0) && ((gameMode2 & CHEAT_INVISIBLE) == 0))
+	{
+		driver->invisibleTimer = CTR_MipsSubLo(driver->invisibleTimer, msPerFrame);
+
+		// if newly visible
+		if (driver->invisibleTimer <= 0)
+		{
+			driver->invisibleTimer = 0;
+			driver->instSelf->flags = driver->instFlagsBackup;
+			driver->instSelf->alphaScale = 0;
+			OtherFX_Play(VEH_PHYS_PROC_INVISIBLE_REAPPEAR_FX, 1);
 		}
 	}
 
@@ -1916,10 +1918,13 @@ void VehPhysProc_PowerSlide_PhysAngular(struct Thread *th, struct Driver *driver
 	// near-spinout distortion SFX
 	driver->turnWobbleAngle = turnWobbleAngleNext;
 
-	driver->ampTurnState = (s16)CTR_MipsAddLo(signedSpinRate, driftTurnInput);
+	// Retail keeps the 32-bit sum live and only truncates on the store, so the
+	// multiply below must not go through the s16 field.
+	int ampTurnState = CTR_MipsAddLo(signedSpinRate, driftTurnInput);
+	driver->ampTurnState = (s16)ampTurnState;
 
 	driver->angle = (s16)ANG_MODULO_TWO_PI(
-	    CTR_MipsAddLo((u16)driver->angle, CTR_MipsSra(CTR_MipsMulLo(driver->ampTurnState, gGT->elapsedTimeMS), VEH_PHYS_PROC_ANGLE_INTEGRATION_SHIFT)));
+	    CTR_MipsAddLo((u16)driver->angle, CTR_MipsSra(CTR_MipsMulLo(ampTurnState, gGT->elapsedTimeMS), VEH_PHYS_PROC_ANGLE_INTEGRATION_SHIFT)));
 
 	if (driver->KartStates.Drifting.driftBoostTimeMS != 0)
 	{

--- a/game/Vehicle/VehPhysProc.c
+++ b/game/Vehicle/VehPhysProc.c
@@ -633,8 +633,13 @@ void VehPhysProc_Driving_PhysLinear(struct Thread *thread, struct Driver *driver
 		buttonsTapped = ptrgamepad->buttonsTapped;
 	}
 
-	cross = buttonsHeld & BTN_CROSS;
-	square = buttonsHeld & BTN_SQUARE;
+	// Retail masks only the "_one" bits here (andi 0x10 / andi 0x20 at 0x80062030
+	// and 0x80062038); the combined BTN_CROSS / BTN_SQUARE masks appear nowhere in
+	// the retail EXE. Both bits always travel together because the two
+	// gamepadMapBtn entries share the same rawInput, so this is equivalent, but
+	// retail takes prevalence.
+	cross = buttonsHeld & BTN_CROSS_one;
+	square = buttonsHeld & BTN_SQUARE_one;
 
 	// state of kart
 	kartState = driver->kartState;
@@ -1814,7 +1819,10 @@ void VehPhysProc_PowerSlide_PhysAngular(struct Thread *th, struct Driver *driver
 
 	int turnAngleStep = CTR_MipsSra(turnAngleDelta, VEH_PHYS_PROC_DRIFT_ANGLE_LERP_SHIFT);
 
-	int turnAngleStepSigned = (s16)turnAngleStep;
+	// Retail keeps this step 32-bit and only truncates on the store below, same
+	// as the ampTurnState sum further down. The result is identical either way
+	// (both reduce mod 2^16), but retail takes prevalence.
+	int turnAngleStepSigned = turnAngleStep;
 	if (turnAngleDelta != 0)
 	{
 		if (turnAngleStep == 0)

--- a/game/Vehicle/VehPickupItem.c
+++ b/game/Vehicle/VehPickupItem.c
@@ -502,7 +502,9 @@ b32 VehPickupItem_PotionThrow(struct MineWeapon *mine, struct Instance *inst, u3
 				return 0;
 			}
 
-			throwVelocity = (MixRNG_Scramble() & POTION_THROW_RANDOM_MASK) - POTION_THROW_RANDOM_BIAS;
+			// Retail draws from advRng here, not from the MixRNG stream the item
+			// roulette uses.
+			throwVelocity = (RngDeadCoed(&sdata->advRng) & POTION_THROW_RANDOM_MASK) - POTION_THROW_RANDOM_BIAS;
 		}
 		else
 		{

--- a/game/Vehicle/VehPickupItem.c
+++ b/game/Vehicle/VehPickupItem.c
@@ -26,7 +26,6 @@ static inline void VehPickupItem_ClearMineMotion(struct MineWeapon *mine)
 
 enum
 {
-	MASK_GOOD_GUY_CHARACTER_BITS = 0x20c9,
 	MASK_MODEL_COUNT = 2,
 	MASK_SOUND_ID_OFFSET_FROM_MODEL = 0x1a,
 	MASK_BEAM_MODEL_STRIDE = 2,
@@ -132,7 +131,6 @@ enum
 	VOICELINE_WEAPON_PRIORITY = 0x10,
 };
 
-CTR_STATIC_ASSERT(MASK_GOOD_GUY_CHARACTER_BITS == 0x20c9);
 CTR_STATIC_ASSERT(MASK_MODEL_COUNT == 2);
 CTR_STATIC_ASSERT(MASK_SOUND_ID_OFFSET_FROM_MODEL == 0x1a);
 CTR_STATIC_ASSERT(MASK_BEAM_MODEL_STRIDE == 2);
@@ -236,10 +234,14 @@ b32 VehPickupItem_MaskBoolGoodGuy(struct Driver *d)
 {
 	s32 charID = data.characterIDs[d->driverID];
 
-	// Crash, Coco, Pura, Polar, Penta
-	u32 maskBits = MASK_GOOD_GUY_CHARACTER_BITS;
+	// Retail compares against each ID in turn instead of indexing a bitmask, so
+	// any charID outside the set returns 0 no matter how large or negative it is.
+	if ((charID == CRASH_BANDICOOT) || (charID == COCO_BANDICOOT) || (charID == POLAR) || (charID == PURA) || (charID == PENTA_PENGUIN))
+	{
+		return 1;
+	}
 
-	return (maskBits >> charID) & 1;
+	return 0;
 }
 
 // NOTE(aalhendi): ASM-verified NTSC-U 926 0x80064c38-0x80064f94.
@@ -535,8 +537,7 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 	struct TrackerWeapon *tw;
 	struct GameTracker *gGT = sdata->gGT;
 	int modelID;
-	int mineHitModel = 0;
-	int mineShouldInitFollower = 0;
+	int mineHitModelFlags = 0;
 
 	switch (weaponID)
 	{
@@ -632,19 +633,21 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 		dInst = d->instSelf;
 
-		// set up missile
-		modelID = DYNAMIC_ROCKET;
-		int bucket = TRACKING;
-		struct Thread *parentTh = 0;
-		char *weaponName = rdata.s_bombtracker1;
+		// set up bomb
+		modelID = DYNAMIC_BOMB;
+		int bucket = OTHER;
+		struct Thread *parentTh = dInst->thread;
+		char *weaponName = sdata->s_bomb1;
 
-		// bomb
-		if ((d->heldItemID == HELD_ITEM_BOMB_1X) || (d->heldItemID == HELD_ITEM_BOMB_3X))
+		// missile. Retail asks "is it a missile?" here (0x80065640) and "is it a
+		// bomb?" at every other branch of this case, so keep both questions in
+		// their retail form instead of collapsing them into one.
+		if ((d->heldItemID == HELD_ITEM_MISSILE_1X) || (d->heldItemID == HELD_ITEM_MISSILE_3X))
 		{
-			modelID = DYNAMIC_BOMB;
-			bucket = OTHER;
-			parentTh = dInst->thread;
-			weaponName = sdata->s_bomb1;
+			modelID = DYNAMIC_ROCKET;
+			bucket = TRACKING;
+			parentTh = 0;
+			weaponName = rdata.s_bombtracker1;
 		}
 
 		// medium stack pool
@@ -674,8 +677,8 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 		int talk;
 
-		// bomb
-		if (modelID == DYNAMIC_BOMB)
+		// bomb (retail 0x80065760)
+		if ((d->heldItemID == HELD_ITEM_BOMB_1X) || (d->heldItemID == HELD_ITEM_BOMB_3X))
 		{
 			talk = VOICELINE_BOMB_LAUNCH;
 			d->instBombThrow = weaponInst;
@@ -726,8 +729,8 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 			tw->flags |= TRACKER_FLAG_POWERED_UP;
 		}
 
-		// bomb
-		if (modelID == DYNAMIC_BOMB)
+		// bomb (retail 0x80065854)
+		if ((d->heldItemID == HELD_ITEM_BOMB_1X) || (d->heldItemID == HELD_ITEM_BOMB_3X))
 		{
 			struct GamepadBuffer *gb = &sdata->gGamepads->gamepad[d->driverID];
 
@@ -807,8 +810,10 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 		RB_MinePool_Add(mw);
 		VehPickupItem_PotionThrow(mw, weaponInst, flags);
-		mineHitModel = weaponInst->model->id | COLL_MODELID_BLOCKAGE_FLAG;
-		mineShouldInitFollower = (flags == 0);
+
+		// Only the TNT/nitro copy of the block below ORs in the blockage bit
+		// (retail 0x8006616c); the beaker copy does not (0x80066534).
+		mineHitModelFlags = COLL_MODELID_BLOCKAGE_FLAG;
 
 	RunMineCOLL:;
 
@@ -840,7 +845,7 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 		if (sps->boolDidTouchHitbox != 0)
 		{
-			sps->Input1.modelID = mineHitModel;
+			sps->Input1.modelID = weaponInst->model->id | mineHitModelFlags;
 
 			RB_Hazard_CollLevInst(sps, weaponTh);
 
@@ -859,6 +864,11 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 			sps->Union.QuadBlockColl.searchFlags = 0;
 			COLL_SearchBSP_CallbackQUADBLK(&probeTop, &probeBottom, sps, 0);
+		}
+
+		else
+		{
+			mw->crateInst = 0;
 		}
 
 		RB_MakeInstanceReflective(sps, weaponInst);
@@ -882,17 +892,29 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 		VehPhysForce_RotAxisAngle(&weaponInst->matrix, rotationNormal, d->angle);
 
+		// Retail inlines this block twice. The TNT/nitro copy (0x80066250) sets
+		// instTntSend and the flag before the follower and only spawns it when no
+		// throw was requested; the beaker copy (0x8006660c) always spawns the
+		// follower and sets the flag afterwards.
 		if (weaponID == WEAPON_ID_MINE)
 		{
 			d->instTntSend = weaponInst;
+
+			// dropped a mine
+			d->actionsFlagSet |= ACTION_DROPPING_MINE;
+
+			if (flags == 0)
+			{
+				RB_Follower_Init(d, weaponTh);
+			}
 		}
 
-		// dropped a mine
-		d->actionsFlagSet |= ACTION_DROPPING_MINE;
-
-		if (mineShouldInitFollower != 0)
+		else
 		{
 			RB_Follower_Init(d, weaponTh);
+
+			// dropped a mine
+			d->actionsFlagSet |= ACTION_DROPPING_MINE;
 		}
 		break;
 
@@ -908,12 +930,20 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 			{
 				return;
 			}
+
+			weaponTh = weaponInst->thread;
+			mw = weaponTh->object;
+			mw->flags = 0;
 		}
 		else
 		{
 			modelID = STATIC_BEAKER_RED;
 
 			weaponInst = INSTANCE_BirthWithThread(modelID, sdata->s_beaker1, SMALL, MINE, RB_GenericMine_ThTick, sizeof(struct MineWeapon), 0);
+
+			weaponTh = weaponInst->thread;
+			mw = weaponTh->object;
+			mw->flags = MINE_WEAPON_FLAG_RED_BEAKER;
 		}
 
 		dInst = d->instSelf;
@@ -923,9 +953,19 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 		// potion always faces camera
 		weaponInst->model->headers[0].flags |= BEAKER_MODEL_HEADER_CAMERA_FLAG;
 
-		weaponTh = weaponInst->thread;
 		weaponTh->funcThDestroy = PROC_DestroyInstance;
 		weaponTh->funcThCollide = (void *)RB_Hazard_ThCollide_Generic;
+
+		// Retail only clears driverTarget on the TNT/nitro path, so a
+		// beaker inherits whatever the recycled pool object held. Nothing reads it
+		// for a beaker today (RB_Hazard and RB_TNT both gate on STATIC_CRATE_TNT),
+		// but native clears it rather than keep a live garbage pointer around.
+		mw->driverTarget = 0;
+
+		mw->parentSafetyFrames = MINE_PARENT_SAFETY_FRAMES;
+		mw->boolDestroyed = 0;
+		mw->crateInst = 0;
+		mw->instParent = dInst;
 
 		PlaySound3D(SOUND_MINE_DROP, weaponInst);
 
@@ -935,28 +975,18 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 			Voiceline_RequestPlay(VOICELINE_MINE_DROP, data.characterIDs[d->driverID], VOICELINE_WEAPON_PRIORITY);
 		}
 
-		mw = weaponTh->object;
-		mw->driverTarget = 0;
-		mw->instParent = dInst;
-		mw->crateInst = 0;
-		mw->boolDestroyed = 0;
-		mw->parentSafetyFrames = MINE_PARENT_SAFETY_FRAMES;
-		mw->flags = 0;
-		if (modelID == STATIC_BEAKER_RED)
-		{
-			mw->flags = MINE_WEAPON_FLAG_RED_BEAKER;
-		}
-
 		struct GamepadBuffer *gb = &sdata->gGamepads->gamepad[d->driverID];
 
-		// throw potion forward
+		// throw potion forward. Retail ORs the bit into the argument only, it
+		// never writes it back to the caller's flags.
+		s32 throwFlags = flags;
 		if ((gb->buttonsHeldCurrFrame & BTN_UP) != 0)
 		{
-			flags |= POTION_THROW_FORWARD;
+			throwFlags |= POTION_THROW_FORWARD;
 		}
 
 		RB_MinePool_Add(mw);
-		b32 didThrowPotion = VehPickupItem_PotionThrow(mw, weaponInst, flags);
+		b32 didThrowPotion = VehPickupItem_PotionThrow(mw, weaponInst, throwFlags);
 
 		if (didThrowPotion == 0)
 		{
@@ -966,8 +996,7 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 
 			VehPickupItem_ClearMineMotion(mw);
 
-			mineHitModel = weaponInst->model->id;
-			mineShouldInitFollower = 1;
+			mineHitModelFlags = 0;
 			goto RunMineCOLL;
 		}
 		break;
@@ -988,29 +1017,25 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 		weaponTh->funcThDestroy = PROC_DestroyInstance;
 		OtherFX_Play(SOUND_SHIELD, 1);
 
+		struct Shield *shieldObj = weaponTh->object;
+
 		modelID = DYNAMIC_SHIELD_GREEN;
 		if (d->numWumpas >= DRIVER_WUMPA_JUICED_COUNT)
 		{
 			modelID = DYNAMIC_SHIELD;
 		}
 
-		struct Instance *instColor = INSTANCE_Birth3D(gGT->modelPtr[modelID], sdata->s_shield, weaponTh);
+		shieldObj->instColor = INSTANCE_Birth3D(gGT->modelPtr[modelID], sdata->s_shield, weaponTh);
+		shieldObj->instColor->scale.x = SHIELD_SCALE;
+		shieldObj->instColor->scale.y = SHIELD_SCALE;
+		shieldObj->instColor->scale.z = SHIELD_SCALE;
 
-		struct Instance *instHighlight = INSTANCE_Birth3D(gGT->modelPtr[DYNAMIC_HIGHLIGHT], highlightName, weaponTh);
+		shieldObj->instHighlight = INSTANCE_Birth3D(gGT->modelPtr[DYNAMIC_HIGHLIGHT], highlightName, weaponTh);
+		shieldObj->instHighlight->scale.x = SHIELD_SCALE;
+		shieldObj->instHighlight->scale.y = SHIELD_SCALE;
+		shieldObj->instHighlight->scale.z = SHIELD_SCALE;
 
-		instColor->scale.x = SHIELD_SCALE;
-		instColor->scale.y = SHIELD_SCALE;
-		instColor->scale.z = SHIELD_SCALE;
-
-		instHighlight->scale.x = SHIELD_SCALE;
-		instHighlight->scale.y = SHIELD_SCALE;
-		instHighlight->scale.z = SHIELD_SCALE;
-
-		struct Shield *shieldObj = weaponTh->object;
-		shieldObj->animFrame = 0;
 		shieldObj->flags = 0;
-		shieldObj->instColor = instColor;
-		shieldObj->instHighlight = instHighlight;
 		shieldObj->highlightRot.x = 0;
 		shieldObj->highlightRot.y = SHIELD_HIGHLIGHT_ROT_Y;
 		shieldObj->highlightRot.z = 0;
@@ -1026,6 +1051,10 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 		}
 
 		weaponInst->alphaScale = SHIELD_ALPHA_SCALE;
+
+		// Retail clears animFrame last, after the duration/flag branch.
+		shieldObj->animFrame = 0;
+
 		d->instBubbleHold = weaponInst;
 		break;
 
@@ -1082,7 +1111,6 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 	// Warpball
 	case WEAPON_ID_WARPBALL:
 
-		dInst = d->instSelf;
 		GAMEPAD_ShockFreq(d, WEAPON_GAMEPAD_RUMBLE_FRAMES, 0);
 		GAMEPAD_ShockForce1(d, WEAPON_GAMEPAD_RUMBLE_FRAMES, WEAPON_GAMEPAD_RUMBLE_FORCE);
 
@@ -1116,47 +1144,51 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 			Voiceline_RequestPlay(VOICELINE_WARPBALL, data.characterIDs[d->driverID], VOICELINE_WEAPON_PRIORITY);
 		}
 
+		tw = weaponTh->object;
+		tw->driverParent = d;
+		tw->turnAroundFrames = 0;
+		tw->ptrNodeNext = 0;
+
 		// used by RB_Warpball_SeekDriver
 		victim = 0;
-		int rank = d->driverRank;
-		if (rank != 0)
+		if (d->driverRank != 0)
 		{
-			victim = gGT->driversInRaceOrder[rank - 1];
+			victim = gGT->driversInRaceOrder[d->driverRank - 1];
 		}
-
-		tw = weaponTh->object;
-		tw->flags = TRACKER_FLAG_WARPBALL_FALLBACK_PATH;
-		tw->soundIDCount = 0;
-		tw->ptrNodeNext = 0;
-		tw->pathProgress = 0;
-		tw->turnAroundFrames = 0;
-		tw->driverParent = d;
 		tw->driverTarget = victim;
-		tw->instParent = dInst;
+
+		// sets nodeCurrIndex
+		RB_Warpball_SeekDriver(tw, d->checkpoint.currentIndex, d);
+
+		// Retail initializes flags and pathProgress AFTER SeekDriver, not before.
+		struct CheckpointNode *cn = gGT->level1->ptr_restart_points;
+		tw->nodeNextIndex = tw->nodeCurrIndex;
+		tw->flags = 0;
+		tw->pathProgress = 0;
+		tw->ptrNodeCurr = &cn[tw->nodeCurrIndex];
 
 		if (d->numWumpas >= DRIVER_WUMPA_JUICED_COUNT)
 		{
 			tw->flags |= TRACKER_FLAG_POWERED_UP;
 		}
 
-		// sets nodeCurrIndex
-		RB_Warpball_SeekDriver(tw, d->checkpoint.currentIndex, d);
-
-		struct CheckpointNode *cn = gGT->level1->ptr_restart_points;
-		tw->nodeNextIndex = tw->nodeCurrIndex;
-		tw->ptrNodeCurr = &cn[tw->nodeCurrIndex];
+		tw->flags |= TRACKER_FLAG_WARPBALL_FALLBACK_PATH;
 
 		// make this driver invincible
 		tw->driversHit = 1 << d->driverID;
 
-		victim = 0;
-		if (rank != 0)
+		// Retail re-reads driverRank and driverTarget here rather than reusing
+		// the values it computed before SeekDriver.
+		if (d->driverRank != 0)
 		{
-			victim = RB_Warpball_GetDriverTarget(tw, weaponInst);
+			tw->driverTarget = RB_Warpball_GetDriverTarget(tw, weaponInst);
 		}
-		tw->driverTarget = victim;
+		else
+		{
+			tw->driverTarget = 0;
+		}
 
-		if (victim != 0)
+		if (tw->driverTarget != 0)
 		{
 			RB_Warpball_SetTargetDriver(tw);
 		}
@@ -1170,16 +1202,23 @@ void VehPickupItem_ShootNow(struct Driver *d, s32 weaponID, s32 flags)
 			tw->flags &= ~TRACKER_FLAG_WARPBALL_FALLBACK_PATH;
 		}
 
-		tw->ptrNodeNext = RB_Warpball_NewPathNode(tw->ptrNodeCurr, victim);
+		tw->ptrNodeNext = RB_Warpball_NewPathNode(tw->ptrNodeCurr, tw->driverTarget);
 
-		tw->vel.y = 0;
-		tw->rotY = d->angle;
-		tw->parentSafetyFrames = WARPBALL_PARENT_SAFETY_FRAMES;
+		tw->soundIDCount = 0;
+
+		dInst = d->instSelf;
 
 		// do NOT patch for 60fps,
 		// velocity uses elapsedTime
+		tw->vel.y = 0;
 		tw->vel.x = (dInst->matrix.m[0][2] * WARPBALL_VELOCITY_NUMERATOR) >> WARPBALL_VELOCITY_SHIFT;
+		tw->parentSafetyFrames = WARPBALL_PARENT_SAFETY_FRAMES;
 		tw->vel.z = (dInst->matrix.m[2][2] * WARPBALL_VELOCITY_NUMERATOR) >> WARPBALL_VELOCITY_SHIFT;
+
+		// Retail seeds dir.y (0x1a), not rotY (0x1e): RB_Warpball only ever reads
+		// dir.y, and it interpolates from the previous value.
+		tw->dir.y = d->angle;
+		tw->instParent = dInst;
 
 		struct Particle *p = Particle_Init(0, gGT->iconGroup[WARPBALL_PARTICLE_ICON_GROUP], &data.emSet_Warpball[0]);
 

--- a/game/Vehicle/VehStuckProc.c
+++ b/game/Vehicle/VehStuckProc.c
@@ -526,11 +526,15 @@ void VehStuckProc_MaskGrab_Animate(struct Thread *t, struct Driver *d)
 	// set mask posZ
 	mask->pos.z = (s16)CTR_MipsSra(d->posCurr.z, FRACTIONAL_BITS_8);
 
+	// Retail compares the s16 mask height against the untruncated
+	// posCurr.y >> 8 and only narrows on the store.
+	int driverHeight = CTR_MipsSra(d->posCurr.y, FRACTIONAL_BITS_8);
+
 	// if mask posY < driver posY
-	if (mask->pos.y < (s16)CTR_MipsSra(d->posCurr.y, FRACTIONAL_BITS_8))
+	if (mask->pos.y < driverHeight)
 	{
 		// mask posY = driver posY
-		mask->pos.y = (s16)CTR_MipsSra(d->posCurr.y, FRACTIONAL_BITS_8);
+		mask->pos.y = (s16)driverHeight;
 
 		d->KartStates.MaskGrab.boolLiftingPlayer = true;
 	}

--- a/game/Vehicle/VehTurbo.c
+++ b/game/Vehicle/VehTurbo.c
@@ -288,7 +288,7 @@ void VehTurbo_ThTick(struct Thread *turboThread)
 	// player of any kind
 	if (instanceDriver->thread->modelIndex == DYNAMIC_PLAYER)
 	{
-		int fireSfxVolume = TURBO_AUDIO_VOLUME_BASE - (u32)(instance->alphaScale >> TURBO_AUDIO_ALPHA_SHIFT);
+		int fireSfxVolume = TURBO_AUDIO_VOLUME_BASE - (int)(instance->alphaScale >> TURBO_AUDIO_ALPHA_SHIFT);
 
 		if (fireSfxVolume < 0)
 		{

--- a/game/zGlobal_SDATA.c
+++ b/game/zGlobal_SDATA.c
@@ -19,7 +19,7 @@ struct sData sdata_static = {.langBufferSize = 0x3F04,
                              .cup_difficultyParams = &sdata_static.cupDiff[0],
 #endif
 
-                             .driver_pathIndexIDs = {0, -1, -1, 2, 0, -1, -1, 2},
+                             .driver_pathIndexIDs = {0, 0xff, 0xff, 2, 0, 0xff, 0xff, 2},
 
                              // twice as many frames, half as much
                              // step for each frame of acceleration

--- a/include/ctr_math.h
+++ b/include/ctr_math.h
@@ -234,6 +234,18 @@ static inline u32 CTR_MipsDivU(u32 dividend, u32 divisor)
 	return dividend / divisor;
 }
 
+// MIPS `divu` + `mfhi`. Same deal as CTR_MipsRem, minus the INT_MIN / -1 pair
+// that only exists for the signed opcode.
+static inline u32 CTR_MipsRemU(u32 dividend, u32 divisor)
+{
+	if (divisor == 0)
+	{
+		CTR_TRAP();
+	}
+
+	return dividend % divisor;
+}
+
 // misc //
 
 #ifndef CTR_NATIVE

--- a/include/ctr_math.h
+++ b/include/ctr_math.h
@@ -209,6 +209,21 @@ static inline s32 CTR_MipsDiv(s32 dividend, s32 divisor)
 	return dividend / divisor;
 }
 
+// MIPS `div` + `mfhi`. Retail's compiler emits an explicit `break` for the two
+// operand pairs the hardware leaves undefined, so trap on them here too instead
+// of letting C's `%` invoke undefined behaviour.
+static inline s32 CTR_MipsRem(s32 dividend, s32 divisor)
+{
+	const s32 minS32 = (-2147483647 - 1);
+
+	if ((divisor == 0) || ((divisor == -1) && (dividend == minS32)))
+	{
+		CTR_TRAP();
+	}
+
+	return dividend % divisor;
+}
+
 static inline u32 CTR_MipsDivU(u32 dividend, u32 divisor)
 {
 	if (divisor == 0)

--- a/include/functions.h
+++ b/include/functions.h
@@ -148,7 +148,7 @@ void OtherFX_Stop1(int soundID_count);
 void OtherFX_Stop2(int soundID_count);
 void OtherFX_RecycleNew(u32 *soundID_Count, u32 newSoundID, u32 modifyFlags);
 void OtherFX_RecycleMute(u32 *soundID_Count);
-b32 EngineAudio_InitOnce(u32 soundID, u32 flags);
+b32 EngineAudio_InitOnce(u16 soundID, u32 flags);
 s16 EngineAudio_Recalculate(u32 soundID, u32 sfx);
 void EngineAudio_Stop(u32 soundID);
 void SetReverbMode(u16 newReverbMode);

--- a/include/functions.h
+++ b/include/functions.h
@@ -457,7 +457,7 @@ void TRIG_AngleSinCos_r15r16r17(u32 angle, s32 *sine, s32 *cosine);
 void TRIG_AngleSinCos_r16r17r18_duplicate(u32 angle, u32 *sine, u32 *cosine);
 void TRIG_AngleSinCos_r9r8r10(u32 angle, s32 *sine, s32 *cosine);
 void TRIG_AngleSinCos_r16r17r18(u32 angle, s32 *sine, s32 *cosine);
-MATRIX *MATH_HitboxMatrix(MATRIX *output, MATRIX *input);
+void MATH_HitboxMatrix(MATRIX *output, MATRIX *input);
 void ConvertRotToMatrix_InverseTranspose_NoRotY(MATRIX *m, const SVec3 *rot);
 void ConvertRotToMatrix_InverseTranspose(MATRIX *m, const SVec3 *rot);
 void ConvertRotToMatrix(MATRIX *m, const SVec3 *rot);
@@ -574,7 +574,7 @@ void RECTMENU_Show(struct RectMenu *m);
 
 int MixRNG_Scramble(void);
 int MixRNG_Particles(int param_1);
-u32 MixRNG_GetValue(int param_1);
+int MixRNG_GetValue(int param_1);
 int RngDeadCoed(struct RngDeadCoedState *state);
 
 void MainStats_ClearBattleVS(void);
@@ -1311,7 +1311,7 @@ b32 MainFrame_HaveAllPads(s16 numPlyrNextGame);
 void RB_CtrLetter_ThTick(struct Thread *t);
 void BOTS_ThTick_Drive(struct Thread *botThread);
 void BOTS_ThTick_RevEngine(struct Thread *botThread);
-void BOTS_SetRotation(struct Driver *driver, int useSpawnYaw);
+void BOTS_SetRotation(struct Driver *driver, s16 useSpawnYaw);
 u32 BOTS_ChangeState(struct Driver *driverVictim, int damageType, struct Driver *driverAttacker, int reason);
 void BOTS_LevInstColl(struct Thread *botThread);
 void BOTS_Killplane(struct Thread *botThread);

--- a/include/functions.h
+++ b/include/functions.h
@@ -117,7 +117,7 @@ void GAMEPAD_ProcessSticks(struct GamepadSystem *gGamepads);
 int GAMEPAD_ProcessTapRelease(struct GamepadSystem *gGamepads);
 void GAMEPAD_ProcessMotors(struct GamepadSystem *gGamepads);
 int GAMEPAD_ProcessAnyoneVars(struct GamepadSystem *gGamepads);
-void GAMEPAD_ProcessState(struct GamepadBuffer *pad, int padState, s16 id);
+void GAMEPAD_ProcessState(struct GamepadBuffer *pad, int padState, int id);
 void GAMEPAD_ShockForce2(struct Driver *d, int frame, int val);
 
 b32 GAMEPROG_CheckGhostsBeaten(int ghostID);

--- a/include/namespace_Camera.h
+++ b/include/namespace_Camera.h
@@ -224,7 +224,9 @@ struct CameraDC
 	u16 mode;
 
 	// 0x0A
-	u16 nearOrFar;
+	// Retail's only load of this field (CAM_ThTick 0x8001b478) is an `lh` whose
+	// result indexes ZoomData without being truncated back to 16 bits.
+	s16 nearOrFar;
 
 	// 0xC
 	u32 unk0xC;

--- a/include/namespace_Instance.h
+++ b/include/namespace_Instance.h
@@ -451,10 +451,19 @@ struct InstDef
 	SVec3 rot;
 
 	// 0x3c
-	int modelID;
+	// Retail reads this with `lh` at every site (VehBirth_TeleportSelf,
+	// BOTS_LevInstColl, COLL_MOVED_PlayerSearch, VehPickupItem_ShootNow):
+	// the field is 16-bit signed, not a word.
+	s16 modelID;
+
+	// 0x3e
+	s16 padding_0x3e;
 
 	// 0x40 -- struct size
 };
+
+CTR_STATIC_ASSERT(sizeof(struct InstDef) == 0x40);
+CTR_STATIC_ASSERT(OFFSETOF(struct InstDef, modelID) == 0x3c);
 
 struct InstDrawPerPlayer
 {

--- a/include/namespace_Instance.h
+++ b/include/namespace_Instance.h
@@ -574,7 +574,10 @@ struct Instance
 	SVec3 scale;
 
 	// 0x22
-	s16 alphaScale;
+	// Retail reads this only with `lhu`, and every operation on it is unsigned:
+	// `srl` in VehTurbo_ThTick (0x80069444, 0x800699cc) and `sltiu` at
+	// 0x8006990c / 0x80069adc / 0x80069b44. A signed short would give lh/sra/slt.
+	u16 alphaScale;
 
 	// 0x24
 	u32 colorRGBA;

--- a/include/namespace_Main.h
+++ b/include/namespace_Main.h
@@ -1473,7 +1473,8 @@ struct GameTracker
 
 	// 257a
 	// only updated for human players
-	u8 humanPlayerPositions[8];
+	// Retail's only load is `lb` (PlayLevel_UpdateLapStats 0x80041ac4): signed.
+	s8 humanPlayerPositions[8];
 
 	// 2582
 	//  determines if you see Oxide Intro,

--- a/include/namespace_Main.h
+++ b/include/namespace_Main.h
@@ -745,7 +745,9 @@ struct GameTracker
 		int enabledWeapons;
 
 		// 1da4
-		char teamOfEachPlayer[4];
+		// Retail reads this with `lb` in VehBirth_Player: signed byte.
+		// Plain `char` would flip meaning on targets where it is unsigned.
+		s8 teamOfEachPlayer[4];
 
 		// 1da8
 		int finishedRankOfEachTeam[4];
@@ -1442,7 +1444,8 @@ struct GameTracker
 	// all podium related?
 
 	// 2572
-	u16 podiumRewardID;
+	// Retail loads this with `lh` at all 11 read sites; it is signed.
+	s16 podiumRewardID;
 
 	// 2574
 	u8 bool_AdvHub_NeedToSwapLEV;

--- a/include/namespace_Memcard.h
+++ b/include/namespace_Memcard.h
@@ -519,15 +519,17 @@ struct AdvProgress
 	// 8FBD4
 	// Count up to 10 times player lost
 	// Including Crystal Challenge
-	char timesLostRacePerLev[0x12];
+	// Retail reads these with `lb` (signed): BOTS_Adv_AdjustDifficulty x8 and
+	// MainStats. Spelled out as s8 because plain `char` is unsigned on ARM.
+	s8 timesLostRacePerLev[0x12];
 
 	// 8fbe6
 	// Count up to 10 times player lost
-	char timesLostCupRace[5];
+	s8 timesLostCupRace[5];
 
 	// 8FBEB
 	// Count up to 10 times player lost
-	char timesLostBossRace[5];
+	s8 timesLostBossRace[5];
 
 	// 8FBF0
 	// definitely saves to profile

--- a/include/namespace_Proc.h
+++ b/include/namespace_Proc.h
@@ -10,6 +10,16 @@ enum STACK_POOL
 	SMALL = 0x300
 };
 
+// Retail hardcodes these three sizes as immediates in PROC_BirthWithObject
+// (0x670/0x88/0x48) instead of reading JitPool.itemSize back from the pool.
+// They are the same values MainInit passes to JitPool_Init.
+enum STACK_POOL_ITEM_SIZE
+{
+	SMALL_STACK_ITEM_SIZE = 0x48,
+	MEDIUM_STACK_ITEM_SIZE = 0x88,
+	LARGE_STACK_ITEM_SIZE = 0x670
+};
+
 enum THREAD_RELATIVE
 {
 	// yes, both are zero

--- a/include/namespace_Vehicle.h
+++ b/include/namespace_Vehicle.h
@@ -1601,13 +1601,21 @@ struct Driver
 	// 0x484 - last of constants
 
 	// 0x488
-	u32 distanceToFinish_curr;
+	// Retail compares this signed at all 15 sites (`slti`/`slt`/`bgez` in
+	// PlayLevel_UpdateLapStats, BOTS_ThTick_Drive, HOWL and PickupBots);
+	// there is not a single `sltu`/`sltiu` on it.
+	s32 distanceToFinish_curr;
 
 	// 0x48C
+	// Retail only ever loads/stores this as a word, never compares it on its
+	// own, so its signedness is not observable. Kept unsigned: the one place it
+	// is compared (PlayLevel_UpdateLapStats 0x800418a4) is a `sltu` against the
+	// unsigned track length.
 	u32 distanceToFinish_checkpoint;
 
 	// 0x490
-	u32 distanceDrivenBackwards;
+	// Retail compares this signed (`bgez` 0x800415bc, `slti 501` 0x80053198).
+	s32 distanceDrivenBackwards;
 
 	// 0x494
 	struct DriverCheckpointState checkpoint;
@@ -1729,7 +1737,8 @@ struct Driver
 
 	// 0x4fe
 	// 0, 1, 2, depending on rev level
-	char revEngineState;
+	// Retail only ever touches this with sb/lbu, so it is an unsigned byte.
+	u8 revEngineState;
 
 	// 0x4ff
 	u8 pendingDamageType;
@@ -1743,7 +1752,9 @@ struct Driver
 
 	// 0x508
 	// backup of alpha, used for turbo fire
-	s16 alphaScaleBackup;
+	// Retail loads this only with `lhu` (BOTS_ThTick_Drive 0x800151d4,
+	// COLL_FIXED_PlayerSearch 0x8001e054, VehTurbo_ThTick 0x80069aa4).
+	u16 alphaScaleBackup;
 
 	// 0x50A
 	RainCloudEffect rainCloudEffect;
@@ -1941,7 +1952,9 @@ struct Driver
 			RevEngineLockoutFlags lockoutFlags;
 
 			// 0x594
-			int boolMaskGrab;
+			// Retail only ever touches this with sb/lbu, so it is a byte.
+			u8 boolMaskGrab;
+			u8 padding_0x595[3];
 
 			// == end ==
 
@@ -2297,6 +2310,10 @@ CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.RevEngine.releaseCooldownTi
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.RevEngine.emptyCooldownTimerMS) == 0x590);
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.RevEngine.chargeState) == 0x592);
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.RevEngine.lockoutFlags) == 0x593);
+CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.RevEngine.boolMaskGrab) == 0x594);
+CTR_STATIC_ASSERT(sizeof(((struct Driver *)0)->KartStates.RevEngine.boolMaskGrab) == 0x1);
+CTR_STATIC_ASSERT(offsetof(struct Driver, revEngineState) == 0x4fe);
+CTR_STATIC_ASSERT(sizeof(((struct Driver *)0)->revEngineState) == 0x1);
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.Warp) == 0x580);
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.Warp.dustAngle) == 0x58c);
 CTR_STATIC_ASSERT(offsetof(struct Driver, KartStates.Warp.beamHeight) == 0x590);

--- a/include/platform/native_input.h
+++ b/include/platform/native_input.h
@@ -25,6 +25,8 @@ int Platform_InputCycleGamepadController(void);
 
 void Platform_InputPadInit(int slot, unsigned char *padData);
 int Platform_InputPadGetState(int port);
+int Platform_InputPadSetMainMode(int port, int offs, int lock);
+int Platform_InputPadInfoAct(int port, int acno, int term);
 void Platform_InputPadVibrate(int port, unsigned char *table, int len);
 int Platform_InputCapturePadSnapshots(struct PlatformInputPadSnapshot *dst, int count);
 int Platform_InputInstallPadSnapshots(const struct PlatformInputPadSnapshot *src, int count);

--- a/include/psx/inline_c.h
+++ b/include/psx/inline_c.h
@@ -129,11 +129,17 @@ extern int doCOP2(int op);
 		MTC2(*(uint32_t *)((char *)(r2)), 6);  \
 	}
 
-// mtc2 12, lwc2 1
-#define gte_ldlv0(r0)                                                                    \
-	{                                                                                    \
-		MTC2((*(uint16_t *)((char *)(r0) + 4) << 16) | *(uint16_t *)((char *)(r0)), 12); \
-		MTC2(*(uint16_t *)((char *)(r0) + 8), 1);                                        \
+// mtc2 0, lwc2 1
+// Psy-Q 4.4: lhu $13,4(r0); lhu $12,0(r0); sll $13,$13,16; or $12,$12,$13;
+//            mtc2 $12,$0; lwc2 $1,8(r0)
+// The destination was register 12 (SXY0) instead of 0 (VXY0), so V0 was never
+// loaded and the screen-XY FIFO was clobbered instead. The pack also did
+// `(uint16_t)x << 16`, which promotes to int and overflows it for x >= 0x8000;
+// CTR_PackS16Pair does the same thing in u32, where it is defined.
+#define gte_ldlv0(r0)                                                                                   \
+	{                                                                                                   \
+		MTC2(CTR_PackS16Pair(*(uint16_t *)((char *)(r0) + 0), *(uint16_t *)((char *)(r0) + 4)), 0);      \
+		MTC2(CTR_ReadU32LE((char *)(r0) + 8), 1);                                                       \
 	}
 
 // mtc2 8

--- a/include/psx/inline_c.h
+++ b/include/psx/inline_c.h
@@ -188,7 +188,7 @@ extern int doCOP2(int op);
 	{                                             \
 		CTC2(*(uint32_t *)((char *)(r0)), 0);     \
 		CTC2(*(uint32_t *)((char *)(r0) + 4), 2); \
-		CTC2(*(uint32_t*)((char*)(r0 +8), 4);     \
+		CTC2(*(uint32_t *)((char *)(r0) + 8), 4); \
 	}
 
 // lwc2 9,10,11
@@ -206,10 +206,10 @@ extern int doCOP2(int op);
 	}
 
 // ctc2 24,25
-#define gte_SetGeomOffset(r0, r1) \
-	{                             \
-		CTC2(r0 << 16, 24);       \
-		CTC2(r1 << 16, 25);       \
+#define gte_SetGeomOffset(r0, r1)             \
+	{                                         \
+		CTC2((u32)CTR_MipsSll((r0), 16), 24); \
+		CTC2((u32)CTR_MipsSll((r1), 16), 25); \
 	}
 
 // ctc2 13,14,15
@@ -346,7 +346,7 @@ extern int doCOP2(int op);
 
 #define gte_rtv2tr()   doCOP2(0x0490012);
 
-#define gte_rtirtr() op2 0x0498012);
+#define gte_rtirtr()   doCOP2(0x0498012);
 
 #define gte_rtv0bk()                   doCOP2(0x0482012);
 

--- a/include/regionsEXE.h
+++ b/include/regionsEXE.h
@@ -3750,7 +3750,9 @@ struct sData
 	int aiCollisionDelayFrameCount;
 
 	// 8008d69c
-	char kartSpawnOrderArray[0x8];
+	// Retail reads this with `lbu` (VehBirth_TeleportSelf, BOTS_GotoStartingLine):
+	// unsigned byte, not plain `char`.
+	u8 kartSpawnOrderArray[0x8];
 
 	// 8008d6a4
 	char unk_paddingAfterKartSpawn[0x8];

--- a/include/regionsEXE.h
+++ b/include/regionsEXE.h
@@ -2816,7 +2816,9 @@ struct sData
 
 	// 0x8008CF78
 	// path index for each AI
-	char driver_pathIndexIDs[8];
+	// Retail reads this with `lbu` and narrows to signed 8-bit at the use
+	// site (BOTS_Driver_Init, BOTS_Driver_Convert), and writes it with `sb`.
+	u8 driver_pathIndexIDs[8];
 
 	// 0x8008CF80
 	// both these are multiplied by accelerateOrder,
@@ -2887,7 +2889,9 @@ struct sData
 	u32 HudAndDebugFlags;
 
 	// 8008D004
-	char unk_CTR_MatrixToRot_table[0x10];
+	// Retail reads this table only from CTR_MatrixToRot, and all three reads are
+	// `lbu` (unsigned byte): the entries are unsigned, not signed chars.
+	u8 unk_CTR_MatrixToRot_table[0x10];
 
 	// 8008d014
 	// used for "honk" sounds
@@ -3706,7 +3710,10 @@ struct sData
 	// 8008d670
 	// once used to load path files (Spyro 2 demo),
 	// does nothing in retail game
-	int lastPathIndex;
+	// Retail only ever touches this with `sh` (BOTS_SetGlobalNavData) and
+	// never reads it back, so the slot is 16 bits wide.
+	s16 lastPathIndex;
+	s16 pad_8008d672;
 
 	// 8008d674
 	// whoever leads out of all human drivers,
@@ -3747,7 +3754,10 @@ struct sData
 	// 8008c5ec -- JpnTrial
 	// 8008da48 -- EurRetail
 	// 80090abc -- JpnRetail
-	int nav_NumPointsOnPath;
+	// Retail only ever touches this with `sh` (BOTS_SetGlobalNavData) and
+	// never reads it back, so the slot is 16 bits wide.
+	s16 nav_NumPointsOnPath;
+	s16 pad_8008d696;
 
 	// 8008d698
 	int aiCollisionDelayFrameCount;

--- a/include/regionsEXE.h
+++ b/include/regionsEXE.h
@@ -3614,7 +3614,10 @@ struct sData
 	// 80090998 -- JpnRetail
 	// end of race Arcade Adventure
 	// counts 1 - 8 over a few seconds
-	int numIconsEOR;
+	// Retail only ever touches this field 16 bits wide (lh/lhu/sh, never lw/sw):
+	// 8 accesses in the EXE plus 5 in overlay 222. The upper halfword is padding.
+	s16 numIconsEOR;
+	s16 pad_8008d572;
 
 	// 8d574
 	char s_additionInt[4];
@@ -3898,7 +3901,10 @@ struct sData
 	int boolGhostsDrawing;
 
 	// 8008d744
-	int boolGhostTooBigToSave;
+	// Retail only ever touches this field 16 bits wide (sh in the EXE, lh in
+	// overlay 224). The upper halfword is padding.
+	s16 boolGhostTooBigToSave;
+	s16 pad_8008d746;
 
 	// 8008d748
 	int ghostOverflowTextTimer;

--- a/platform/native_gpu.c
+++ b/platform/native_gpu.c
@@ -1813,12 +1813,154 @@ internal int ProcessPsyXPrims(P_TAG *polyTag)
 
 // Processes primitive
 // returns processed primitive primLength in longs
+// PSX GPU polygon size limit.
+//
+// Hardware renders a polygon only while the distance between its vertices stays
+// within 1023 horizontally and 511 vertically; anything larger is discarded by
+// the GPU without drawing a single pixel (psx-spx, "GPU Render Polygon
+// Commands"). Retail depends on that: when a vertex ends up nearer than H/2 the
+// GTE divide overflows and SX/SY saturate to -0400h..+03FFh, producing a
+// triangle that spans the whole screen. On console those simply never appear.
+// RenderBucket's per-primitive gate only rejects FLAG bit 18 (SZ3/OTZ
+// saturated) - verified against retail at 0x8006a5a0 - so it does not catch
+// them either; the GPU size limit is what does.
+//
+// Without this the GL rasteriser happily draws them, which is what shows up as
+// colour streaks across the frame when the camera gets close to an instance.
+#define NATIVE_GPU_MAX_POLY_SPAN_X 1023
+#define NATIVE_GPU_MAX_POLY_SPAN_Y 511
+
+// Drops the just-emitted geometry that exceeds what the PSX GPU would draw.
+//
+// The test is per triangle, not per primitive. A quad is rasterised as two
+// triangles sharing a diagonal, and hardware evaluates each one on its own, so a
+// quad whose opposite corners are more than a span apart still draws both halves
+// as long as neither triangle exceeds the limit by itself. Measuring the whole
+// quad would throw away geometry the console renders.
+//
+// Surviving triangles are compacted down. Split vertex counts are derived from
+// s_gpu.vertexIndex when the split is closed, so an emptied split draws nothing
+// and the recorded state change stays valid for whatever follows.
+//
+// The drawing offset already added by MakeVertex* needs no correction: it is one
+// translation applied to every vertex, so it cannot change a distance, and the
+// hardware likewise measures distances between vertices.
+internal void NativeGpu_ApplyGpuPolygonSizeLimit(int firstVertex)
+{
+	int vertexCount = s_gpu.vertexIndex - firstVertex;
+
+	if ((vertexCount < 3) || (firstVertex < 0))
+	{
+		return;
+	}
+
+	int writeIndex = firstVertex;
+	int dropped = 0;
+
+	for (int group = firstVertex; (group + 3) <= s_gpu.vertexIndex; group += 3)
+	{
+		int minX = 32767;
+		int maxX = -32768;
+		int minY = 32767;
+		int maxY = -32768;
+
+		// Over three vertices the bounding box equals the largest pairwise
+		// distance, which is what the hardware compares.
+		for (int i = 0; i < 3; i++)
+		{
+			const GrVertex *v = &s_gpu.vertexBuffer[group + i];
+
+			minX = (v->x < minX) ? v->x : minX;
+			maxX = (v->x > maxX) ? v->x : maxX;
+			minY = (v->y < minY) ? v->y : minY;
+			maxY = (v->y > maxY) ? v->y : maxY;
+		}
+
+		if (((maxX - minX) > NATIVE_GPU_MAX_POLY_SPAN_X) || ((maxY - minY) > NATIVE_GPU_MAX_POLY_SPAN_Y))
+		{
+			dropped++;
+			continue;
+		}
+
+		if (writeIndex != group)
+		{
+			memmove(&s_gpu.vertexBuffer[writeIndex], &s_gpu.vertexBuffer[group], 3 * sizeof(GrVertex));
+		}
+
+		writeIndex += 3;
+	}
+
+	if (dropped != 0)
+	{
+		s_gpu.vertexIndex = writeIndex;
+	}
+}
+
+// Same hardware limit, applied to lines - psx-spx says "polygons and lines".
+// Each segment is expanded into its own 6-vertex quad here, so a polyline is
+// filtered segment by segment (the limit is per segment on hardware, not per
+// polyline) and the survivors are compacted down.
+//
+// Measuring the expanded quad rather than the two endpoints inflates the span by
+// the line thickness, so a segment sitting exactly on the boundary could differ
+// by a pixel. CTR only draws UI lines, which are bounded by the screen and never
+// come close to 1023x511, so nothing real rides on that.
+internal void NativeGpu_ApplyGpuLineSizeLimit(int firstVertex)
+{
+	int vertexCount = s_gpu.vertexIndex - firstVertex;
+
+	if ((vertexCount < 6) || (firstVertex < 0))
+	{
+		return;
+	}
+
+	int writeIndex = firstVertex;
+	int dropped = 0;
+
+	for (int group = firstVertex; (group + 6) <= s_gpu.vertexIndex; group += 6)
+	{
+		int minX = 32767;
+		int maxX = -32768;
+		int minY = 32767;
+		int maxY = -32768;
+
+		for (int i = 0; i < 6; i++)
+		{
+			const GrVertex *v = &s_gpu.vertexBuffer[group + i];
+
+			minX = (v->x < minX) ? v->x : minX;
+			maxX = (v->x > maxX) ? v->x : maxX;
+			minY = (v->y < minY) ? v->y : minY;
+			maxY = (v->y > maxY) ? v->y : maxY;
+		}
+
+		if (((maxX - minX) > NATIVE_GPU_MAX_POLY_SPAN_X) || ((maxY - minY) > NATIVE_GPU_MAX_POLY_SPAN_Y))
+		{
+			dropped++;
+			continue;
+		}
+
+		if (writeIndex != group)
+		{
+			memmove(&s_gpu.vertexBuffer[writeIndex], &s_gpu.vertexBuffer[group], 6 * sizeof(GrVertex));
+		}
+
+		writeIndex += 6;
+	}
+
+	if (dropped != 0)
+	{
+		s_gpu.vertexIndex = writeIndex;
+	}
+}
+
 int ParsePrimitive(P_TAG *polyTag)
 {
 	const int primType = polyTag->code & 0xF0;
 
 	int primLength = 0;
 	bool handledZeroLength = false;
+	const int sizeLimitFirstVertex = s_gpu.vertexIndex;
 
 	switch (primType)
 	{
@@ -1892,18 +2034,22 @@ int ParsePrimitive(P_TAG *polyTag)
 	case 0x20:
 		// Flat polygons
 		primLength = ProcessFlatPoly(polyTag);
+		NativeGpu_ApplyGpuPolygonSizeLimit(sizeLimitFirstVertex);
 		break;
 	case 0x30:
 		// Gouraud shaded polygons
 		primLength = ProcessGouraudPoly(polyTag);
+		NativeGpu_ApplyGpuPolygonSizeLimit(sizeLimitFirstVertex);
 		break;
 	case 0x40:
 		// Flat (single colour) Lines
 		primLength = ProcessFlatLines(polyTag);
+		NativeGpu_ApplyGpuLineSizeLimit(sizeLimitFirstVertex);
 		break;
 	case 0x50:
 		// Gouraud lines
 		primLength = ProcessGouraudLines(polyTag);
+		NativeGpu_ApplyGpuLineSizeLimit(sizeLimitFirstVertex);
 		break;
 	case 0x60:
 	case 0x70:

--- a/platform/native_gte_core.c
+++ b/platform/native_gte_core.c
@@ -19,10 +19,15 @@ GTERegisters gteRegs;
 
 #define gteop(code)   (code & 0x1ffffff)
 
+/* FLAG masks. Written as `1 << 31` these overflowed a signed int, which is
+ * undefined behaviour; the cast makes every bit position well defined. FLAG
+ * itself (CP2C.p[31].d) and LIM()'s flag parameter are unsigned already. */
+#define GTE_FLAG(bit) ((u32)1 << (bit))
+
 #define VX(n)         (n < 3 ? gteRegs.CP2D.p[n << 1].sw.l : C2_IR1)
 #define VY(n)         (n < 3 ? gteRegs.CP2D.p[n << 1].sw.h : C2_IR2)
 #define VZ(n)         (n < 3 ? gteRegs.CP2D.p[(n << 1) + 1].sw.l : C2_IR3)
-#define MX11(n)       (n < 3 ? gteRegs.CP2C.p[(n << 3)].sw.l : -C2_R << 4)
+#define MX11(n)       (n < 3 ? gteRegs.CP2C.p[(n << 3)].sw.l : -(C2_R << 4))
 #define MX12(n)       (n < 3 ? gteRegs.CP2C.p[(n << 3)].sw.h : C2_R << 4)
 #define MX13(n)       (n < 3 ? gteRegs.CP2C.p[(n << 3) + 1].sw.l : C2_IR0)
 #define MX21(n)       (n < 3 ? gteRegs.CP2C.p[(n << 3) + 1].sw.h : C2_R13)
@@ -84,20 +89,24 @@ internal inline s64 gte_shift(s64 a, int sf)
 	}
 	else if (sf < 0)
 	{
-		return a << 12;
+		return a * 4096;
 	}
 
 	return a;
 }
 
-internal int BOUNDS(/*int44*/ s64 value, int max_flag, int min_flag)
+internal int BOUNDS(/*int44*/ s64 value, u32 max_flag, u32 min_flag)
 {
 	if (value /*.positive_overflow()*/ > (s64)0x7ffffffffff)
 	{
 		C2_FLAG |= max_flag;
 	}
 
-	if (value /*.negative_overflow()*/ < (s64)-0x8000000000)
+	/* MAC1..3 are 44-bit accumulators, so the negative bound is -2^43. The
+	 * literal was one hex digit short (-2^39), which set the MAC negative
+	 * overflow bits 27/26/25 - and with them the error bit 31 - sixteen
+	 * times more eagerly than hardware does. */
+	if (value /*.negative_overflow()*/ < (s64)-0x80000000000)
 	{
 		C2_FLAG |= min_flag;
 	}
@@ -139,28 +148,28 @@ internal u32 gte_divide(u16 numerator, u16 denominator)
 
 internal int A1(/*int44*/ s64 a)
 {
-	return BOUNDS(a, (1 << 31) | (1 << 30), (1 << 31) | (1 << 27));
+	return BOUNDS(a, GTE_FLAG(31) | GTE_FLAG(30), GTE_FLAG(31) | GTE_FLAG(27));
 }
 internal int A2(/*int44*/ s64 a)
 {
-	return BOUNDS(a, (1 << 31) | (1 << 29), (1 << 31) | (1 << 26));
+	return BOUNDS(a, GTE_FLAG(31) | GTE_FLAG(29), GTE_FLAG(31) | GTE_FLAG(26));
 }
 internal int A3(/*int44*/ s64 a)
 {
 	m_mac3 = a;
-	return BOUNDS(a, (1 << 31) | (1 << 28), (1 << 31) | (1 << 25));
+	return BOUNDS(a, GTE_FLAG(31) | GTE_FLAG(28), GTE_FLAG(31) | GTE_FLAG(25));
 }
 internal int Lm_B1(int a, int lm)
 {
-	return LIM(a, 0x7fff, -0x8000 * !lm, (1 << 31) | (1 << 24));
+	return LIM(a, 0x7fff, -0x8000 * !lm, GTE_FLAG(31) | GTE_FLAG(24));
 }
 internal int Lm_B2(int a, int lm)
 {
-	return LIM(a, 0x7fff, -0x8000 * !lm, (1 << 31) | (1 << 23));
+	return LIM(a, 0x7fff, -0x8000 * !lm, GTE_FLAG(31) | GTE_FLAG(23));
 }
 internal int Lm_B3(int a, int lm)
 {
-	return LIM(a, 0x7fff, -0x8000 * !lm, (1 << 22));
+	return LIM(a, 0x7fff, -0x8000 * !lm, GTE_FLAG(22));
 }
 
 internal int Lm_B3_sf(s64 value, int sf, int lm)
@@ -176,7 +185,7 @@ internal int Lm_B3_sf(s64 value, int sf, int lm)
 
 	if (value_12 < -0x8000 || value_12 > 0x7fff)
 	{
-		C2_FLAG |= (1 << 22);
+		C2_FLAG |= GTE_FLAG(22);
 	}
 
 	if (value_sf > max)
@@ -193,26 +202,26 @@ internal int Lm_B3_sf(s64 value, int sf, int lm)
 
 internal int Lm_C1(int a)
 {
-	return LIM(a, 0x00ff, 0x0000, (1 << 21));
+	return LIM(a, 0x00ff, 0x0000, GTE_FLAG(21));
 }
 internal int Lm_C2(int a)
 {
-	return LIM(a, 0x00ff, 0x0000, (1 << 20));
+	return LIM(a, 0x00ff, 0x0000, GTE_FLAG(20));
 }
 internal int Lm_C3(int a)
 {
-	return LIM(a, 0x00ff, 0x0000, (1 << 19));
+	return LIM(a, 0x00ff, 0x0000, GTE_FLAG(19));
 }
 internal int Lm_D(s64 a, int sf)
 {
-	return LIM((int)(gte_shift(a, sf)), 0xffff, 0x0000, (1 << 31) | (1 << 18));
+	return LIM((int)(gte_shift(a, sf)), 0xffff, 0x0000, GTE_FLAG(31) | GTE_FLAG(18));
 }
 
 internal u32 Lm_E(u32 result)
 {
 	if (result == 0xffffffff)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 17);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(17);
 		return 0x1ffff;
 	}
 
@@ -226,31 +235,36 @@ internal u32 Lm_E(u32 result)
 
 internal s64 F(s64 a)
 {
-	m_mac0 = a;
-
+	// Overflow is detected on the full-width sum...
 	if (a > 0x7fffffffLL)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 16);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(16);
 	}
 
 	if (a < -0x80000000LL)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 15);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(15);
 	}
 
-	return a;
+	// ...but MAC0 is a 32-bit register, so that is what gets stored and what
+	// every consumer reads back (SX2/SY2 via SAR 16, IR0 via Lm_H, OTZ via
+	// Lm_D). Keeping the untruncated 64-bit sum here sent SX2/SY2 to the
+	// opposite screen edge whenever IR*(H/SZ) overflowed 32 bits.
+	m_mac0 = (s32)a;
+
+	return m_mac0;
 }
 
 internal int Lm_G1(s64 a)
 {
 	if (a > 0x3ff)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 14);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(14);
 		return 0x3ff;
 	}
 	if (a < -0x400)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 14);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(14);
 		return -0x400;
 	}
 
@@ -261,13 +275,13 @@ internal int Lm_G2(s64 a)
 {
 	if (a > 0x3ff)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 13);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(13);
 		return 0x3ff;
 	}
 
 	if (a < -0x400)
 	{
-		C2_FLAG |= (1 << 31) | (1 << 13);
+		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(13);
 		return -0x400;
 	}
 
@@ -283,7 +297,7 @@ internal int Lm_H(s64 value, int sf)
 
 	if (value_sf < min || value_sf > max)
 	{
-		C2_FLAG |= (1 << 12);
+		C2_FLAG |= GTE_FLAG(12);
 	}
 
 	if (value_12 > max)
@@ -303,9 +317,9 @@ internal int GTE_RotTransPers(int idx, int lm)
 {
 	int h_over_sz3;
 
-	C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_TRX << 12) + (C2_R11 * VX(idx)) + (C2_R12 * VY(idx)) + (C2_R13 * VZ(idx)));
-	C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_TRY << 12) + (C2_R21 * VX(idx)) + (C2_R22 * VY(idx)) + (C2_R23 * VZ(idx)));
-	C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_TRZ << 12) + (C2_R31 * VX(idx)) + (C2_R32 * VY(idx)) + (C2_R33 * VZ(idx)));
+	C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_TRX * 4096) + (C2_R11 * VX(idx)) + (C2_R12 * VY(idx)) + (C2_R13 * VZ(idx)));
+	C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_TRY * 4096) + (C2_R21 * VX(idx)) + (C2_R22 * VY(idx)) + (C2_R23 * VZ(idx)));
+	C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_TRZ * 4096) + (C2_R31 * VX(idx)) + (C2_R32 * VY(idx)) + (C2_R33 * VZ(idx)));
 	C2_IR1 = Lm_B1(C2_MAC1, lm);
 	C2_IR2 = Lm_B2(C2_MAC2, lm);
 	C2_IR3 = Lm_B3_sf(m_mac3, m_sf, lm);
@@ -347,8 +361,10 @@ int GTE_operator(int op)
 		return 1;
 
 	case 0x06:
+		/* NCLIP writes MAC0, so it can legitimately raise the MAC0 overflow
+		 * bits 16/15 (and 31). Clearing FLAG here discarded them; hardware
+		 * only clears FLAG at the start of a command, which is done above. */
 		C2_MAC0 = (int)(F((s64)(C2_SX0 * C2_SY1) + (C2_SX1 * C2_SY2) + (C2_SX2 * C2_SY0) - (C2_SX0 * C2_SY2) - (C2_SX1 * C2_SY0) - (C2_SX2 * C2_SY1)));
-		C2_FLAG = 0;
 		return 1;
 
 	case 0x0c:
@@ -363,9 +379,9 @@ int GTE_operator(int op)
 
 	case 0x10:
 
-		C2_MAC1 = A1((C2_R << 16) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - (C2_R << 16)), 0)));
-		C2_MAC2 = A2((C2_G << 16) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - (C2_G << 16)), 0)));
-		C2_MAC3 = A3((C2_B << 16) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - (C2_B << 16)), 0)));
+		C2_MAC1 = A1((C2_R << 16) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - (C2_R << 16)), 0)));
+		C2_MAC2 = A2((C2_G << 16) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - (C2_G << 16)), 0)));
+		C2_MAC3 = A3((C2_B << 16) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - (C2_B << 16)), 0)));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -379,9 +395,9 @@ int GTE_operator(int op)
 
 	case 0x11:
 
-		C2_MAC1 = A1((C2_IR1 << 12) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - (C2_IR1 << 12)), 0)));
-		C2_MAC2 = A2((C2_IR2 << 12) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - (C2_IR2 << 12)), 0)));
-		C2_MAC3 = A3((C2_IR3 << 12) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - (C2_IR3 << 12)), 0)));
+		C2_MAC1 = A1((C2_IR1 * 4096) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - (C2_IR1 * 4096)), 0)));
+		C2_MAC2 = A2((C2_IR2 * 4096) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - (C2_IR2 * 4096)), 0)));
+		C2_MAC3 = A3((C2_IR3 * 4096) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - (C2_IR3 * 4096)), 0)));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -405,15 +421,15 @@ int GTE_operator(int op)
 			C2_MAC1 = A1((s64)(MX12(mx) * VY(v)) + (MX13(mx) * VZ(v)));
 			C2_MAC2 = A2((s64)(MX22(mx) * VY(v)) + (MX23(mx) * VZ(v)));
 			C2_MAC3 = A3((s64)(MX32(mx) * VY(v)) + (MX33(mx) * VZ(v)));
-			Lm_B1(A1(((s64)CV1(cv) << 12) + (MX11(mx) * VX(v))), 0);
-			Lm_B2(A2(((s64)CV2(cv) << 12) + (MX21(mx) * VX(v))), 0);
-			Lm_B3(A3(((s64)CV3(cv) << 12) + (MX31(mx) * VX(v))), 0);
+			Lm_B1(A1(((s64)CV1(cv) * 4096) + (MX11(mx) * VX(v))), 0);
+			Lm_B2(A2(((s64)CV2(cv) * 4096) + (MX21(mx) * VX(v))), 0);
+			Lm_B3(A3(((s64)CV3(cv) * 4096) + (MX31(mx) * VX(v))), 0);
 			break;
 
 		default:
-			C2_MAC1 = A1(/*int44*/ (s64)((s64)CV1(cv) << 12) + (MX11(mx) * VX(v)) + (MX12(mx) * VY(v)) + (MX13(mx) * VZ(v)));
-			C2_MAC2 = A2(/*int44*/ (s64)((s64)CV2(cv) << 12) + (MX21(mx) * VX(v)) + (MX22(mx) * VY(v)) + (MX23(mx) * VZ(v)));
-			C2_MAC3 = A3(/*int44*/ (s64)((s64)CV3(cv) << 12) + (MX31(mx) * VX(v)) + (MX32(mx) * VY(v)) + (MX33(mx) * VZ(v)));
+			C2_MAC1 = A1(/*int44*/ (s64)((s64)CV1(cv) * 4096) + (MX11(mx) * VX(v)) + (MX12(mx) * VY(v)) + (MX13(mx) * VZ(v)));
+			C2_MAC2 = A2(/*int44*/ (s64)((s64)CV2(cv) * 4096) + (MX21(mx) * VX(v)) + (MX22(mx) * VY(v)) + (MX23(mx) * VZ(v)));
+			C2_MAC3 = A3(/*int44*/ (s64)((s64)CV3(cv) * 4096) + (MX31(mx) * VX(v)) + (MX32(mx) * VY(v)) + (MX33(mx) * VZ(v)));
 			break;
 		}
 
@@ -430,15 +446,15 @@ int GTE_operator(int op)
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
-		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
-		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - ((C2_R << 4) * C2_IR1)), 0)));
-		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - ((C2_G << 4) * C2_IR2)), 0)));
-		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - ((C2_B << 4) * C2_IR3)), 0)));
+		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - ((C2_R << 4) * C2_IR1)), 0)));
+		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - ((C2_G << 4) * C2_IR2)), 0)));
+		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - ((C2_B << 4) * C2_IR3)), 0)));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -452,15 +468,15 @@ int GTE_operator(int op)
 
 	case 0x14:
 
-		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
-		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - ((C2_R << 4) * C2_IR1)), 0)));
-		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - ((C2_G << 4) * C2_IR2)), 0)));
-		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - ((C2_B << 4) * C2_IR3)), 0)));
+		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - ((C2_R << 4) * C2_IR1)), 0)));
+		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - ((C2_G << 4) * C2_IR2)), 0)));
+		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - ((C2_B << 4) * C2_IR3)), 0)));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -482,15 +498,15 @@ int GTE_operator(int op)
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
-			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
-			C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - ((C2_R << 4) * C2_IR1)), 0)));
-			C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - ((C2_G << 4) * C2_IR2)), 0)));
-			C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - ((C2_B << 4) * C2_IR3)), 0)));
+			C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - ((C2_R << 4) * C2_IR1)), 0)));
+			C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - ((C2_G << 4) * C2_IR2)), 0)));
+			C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - ((C2_B << 4) * C2_IR3)), 0)));
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -511,9 +527,9 @@ int GTE_operator(int op)
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
-		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -533,9 +549,9 @@ int GTE_operator(int op)
 
 	case 0x1c:
 
-		C2_MAC1 = A1(/*int44*/ (s64)(((s64)C2_RBK) << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-		C2_MAC2 = A2(/*int44*/ (s64)(((s64)C2_GBK) << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-		C2_MAC3 = A3(/*int44*/ (s64)(((s64)C2_BBK) << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+		C2_MAC1 = A1(/*int44*/ (s64)(((s64)C2_RBK) * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+		C2_MAC2 = A2(/*int44*/ (s64)(((s64)C2_GBK) * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+		C2_MAC3 = A3(/*int44*/ (s64)(((s64)C2_BBK) * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -561,9 +577,9 @@ int GTE_operator(int op)
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
-		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+		C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+		C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+		C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -585,9 +601,9 @@ int GTE_operator(int op)
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
-			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -612,9 +628,9 @@ int GTE_operator(int op)
 
 	case 0x29:
 
-		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - ((C2_R << 4) * C2_IR1)), 0)));
-		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - ((C2_G << 4) * C2_IR2)), 0)));
-		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - ((C2_B << 4) * C2_IR3)), 0)));
+		C2_MAC1 = A1(((C2_R << 4) * C2_IR1) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - ((C2_R << 4) * C2_IR1)), 0)));
+		C2_MAC2 = A2(((C2_G << 4) * C2_IR2) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - ((C2_G << 4) * C2_IR2)), 0)));
+		C2_MAC3 = A3(((C2_B << 4) * C2_IR3) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - ((C2_B << 4) * C2_IR3)), 0)));
 		C2_IR1 = Lm_B1(C2_MAC1, lm);
 		C2_IR2 = Lm_B2(C2_MAC2, lm);
 		C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -630,9 +646,9 @@ int GTE_operator(int op)
 
 		for (v = 0; v < 3; v++)
 		{
-			C2_MAC1 = A1((C2_R0 << 16) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC << 12) - (C2_R0 << 16)), 0)));
-			C2_MAC2 = A2((C2_G0 << 16) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC << 12) - (C2_G0 << 16)), 0)));
-			C2_MAC3 = A3((C2_B0 << 16) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC << 12) - (C2_B0 << 16)), 0)));
+			C2_MAC1 = A1((C2_R0 << 16) + (C2_IR0 * Lm_B1(A1(((s64)C2_RFC * 4096) - (C2_R0 << 16)), 0)));
+			C2_MAC2 = A2((C2_G0 << 16) + (C2_IR0 * Lm_B2(A2(((s64)C2_GFC * 4096) - (C2_G0 << 16)), 0)));
+			C2_MAC3 = A3((C2_B0 << 16) + (C2_IR0 * Lm_B3(A3(((s64)C2_BFC * 4096) - (C2_B0 << 16)), 0)));
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
@@ -710,9 +726,9 @@ int GTE_operator(int op)
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);
-			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK << 12) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
-			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK << 12) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
-			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK << 12) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
+			C2_MAC1 = A1(/*int44*/ (s64)((s64)C2_RBK * 4096) + (C2_LR1 * C2_IR1) + (C2_LR2 * C2_IR2) + (C2_LR3 * C2_IR3));
+			C2_MAC2 = A2(/*int44*/ (s64)((s64)C2_GBK * 4096) + (C2_LG1 * C2_IR1) + (C2_LG2 * C2_IR2) + (C2_LG3 * C2_IR3));
+			C2_MAC3 = A3(/*int44*/ (s64)((s64)C2_BBK * 4096) + (C2_LB1 * C2_IR1) + (C2_LB2 * C2_IR2) + (C2_LB3 * C2_IR3));
 			C2_IR1 = Lm_B1(C2_MAC1, lm);
 			C2_IR2 = Lm_B2(C2_MAC2, lm);
 			C2_IR3 = Lm_B3(C2_MAC3, lm);

--- a/platform/native_gte_core.c
+++ b/platform/native_gte_core.c
@@ -246,13 +246,20 @@ internal s64 F(s64 a)
 		C2_FLAG |= GTE_FLAG(31) | GTE_FLAG(15);
 	}
 
-	// ...but MAC0 is a 32-bit register, so that is what gets stored and what
-	// every consumer reads back (SX2/SY2 via SAR 16, IR0 via Lm_H, OTZ via
-	// Lm_D). Keeping the untruncated 64-bit sum here sent SX2/SY2 to the
-	// opposite screen edge whenever IR*(H/SZ) overflowed 32 bits.
+	// MAC0 is a 32-bit register, so that is what the register keeps and what
+	// IR0 (Lm_H) and OTZ (Lm_D) read back.
 	m_mac0 = (s32)a;
 
-	return m_mac0;
+	// The full-width sum is returned, NOT the truncated register. SX2/SY2 are
+	// produced by shifting this sum right by 16 and only then narrowing, which
+	// is what DuckStation does (`PushSXY(s32(Sx >> 16), ...)` on the 64-bit Sx)
+	// and what Amidog's GTE tests pin down on hardware. Shifting the truncated
+	// register instead wraps the result: OFX + IR1*(H/SZ3) crosses 2^31 as soon
+	// as a vertex approaches the projection plane, and a coordinate that belongs
+	// at a screen edge lands at an arbitrary position, which then stretches the
+	// triangle across the frame. The MAC0 *register* being 32-bit says nothing
+	// about the width of the SX/SY datapath - they are separate.
+	return a;
 }
 
 internal int Lm_G1(s64 a)
@@ -343,6 +350,7 @@ int GTE_operator(int op)
 	int cv;
 	int mx;
 	int h_over_sz3 = 0;
+	s64 dq;
 
 	lm = GTE_LM(gteop(op));
 	m_sf = GTE_SF(gteop(op));
@@ -355,8 +363,14 @@ int GTE_operator(int op)
 	case 0x01:
 		h_over_sz3 = GTE_RotTransPers(0, lm);
 
-		C2_MAC0 = (int)(F((s64)C2_DQB + ((s64)C2_DQA * h_over_sz3)));
-		C2_IR0 = Lm_H(m_mac0, 1);
+		// IR0 is taken from the full-width sum, not from the truncated MAC0
+		// register: same split as SX2/SY2 above. DQA*(H/SZ3) alone reaches
+		// 32767*1FFFFh, so the sum leaves 32-bit range whenever a vertex comes
+		// close, and reading the wrapped register there gives a depth-cue
+		// factor with no relation to the distance.
+		dq = F((s64)C2_DQB + ((s64)C2_DQA * h_over_sz3));
+		C2_MAC0 = (int)dq;
+		C2_IR0 = Lm_H(dq, 1);
 
 		return 1;
 
@@ -680,8 +694,10 @@ int GTE_operator(int op)
 			h_over_sz3 = GTE_RotTransPers(v, lm);
 		}
 
-		C2_MAC0 = (int)(F((s64)C2_DQB + ((s64)C2_DQA * h_over_sz3)));
-		C2_IR0 = Lm_H(m_mac0, 1);
+		// Same full-width IR0 split as RTPS.
+		dq = F((s64)C2_DQB + ((s64)C2_DQA * h_over_sz3));
+		C2_MAC0 = (int)dq;
+		C2_IR0 = Lm_H(dq, 1);
 		return 1;
 
 	case 0x3d:

--- a/platform/native_input.c
+++ b/platform/native_input.c
@@ -20,6 +20,19 @@
 #define NATIVE_INPUT_MAP_FLAG_AXIS         0x4000
 #define NATIVE_INPUT_MAP_FLAG_INVERSE      0x8000
 #define NATIVE_INPUT_DEFAULT_KEYBOARD_SLOT 0
+// A DualShock reports two actuators. libpad's PadInfoAct(port, act, InfoActCurr)
+// gives each one's current draw in the units PadMaxCurr (60) is expressed in;
+// GAMEPAD_ProcessMotors budgets against exactly that. Retail's own comment puts
+// one DualShock at 30 units for both motors together, and it always sheds the
+// large motor first, so the large one carries the bigger share here. The split
+// itself is the one number not documented in psx-spx or in any emulator (they
+// implement the SIO protocol, not libpad).
+#define NATIVE_INPUT_ACTUATOR_COUNT        2
+#define NATIVE_INPUT_ACTUATOR_CURR_SMALL   10
+#define NATIVE_INPUT_ACTUATOR_CURR_LARGE   20
+#define NATIVE_INPUT_INFO_ACT_CURR         4
+#define NATIVE_INPUT_RUMBLE_DURATION_MS    500
+#define NATIVE_INPUT_RUMBLE_REARM_MS       200
 // NOTE(aalhendi): Little-endian tag `CTRI` = CTR native Input snapshot.
 #define NATIVE_INPUT_STATE_MAGIC           0x49525443
 #define NATIVE_INPUT_STATE_VERSION         1
@@ -95,6 +108,11 @@ global_variable s32 s_controllerToSlotMapping[NATIVE_INPUT_MAX_CONTROLLERS] = {-
 global_variable struct NativeInputController s_controllers[NATIVE_INPUT_MAX_CONTROLLERS];
 global_variable struct PlatformInputPadSnapshot s_installedSnapshots[NATIVE_INPUT_MAX_CONTROLLERS];
 global_variable u8 *s_padSlotData[NATIVE_INPUT_PHYSICAL_SLOT_COUNT];
+global_variable const u8 *s_padActTable[NATIVE_INPUT_MAX_CONTROLLERS];
+global_variable s32 s_padActLen[NATIVE_INPUT_MAX_CONTROLLERS];
+global_variable u16 s_padRumbleLarge[NATIVE_INPUT_MAX_CONTROLLERS];
+global_variable u16 s_padRumbleSmall[NATIVE_INPUT_MAX_CONTROLLERS];
+global_variable u64 s_padRumbleSentMs[NATIVE_INPUT_MAX_CONTROLLERS];
 global_variable const bool *s_keyboardState;
 global_variable s32 s_inputInitialized;
 global_variable s32 s_installedSnapshotsActive;
@@ -634,6 +652,18 @@ internal s32 NativeInput_FindSlotForDeviceIndex(Sint32 deviceIndex)
 {
 	s32 slot;
 
+	// SDL queues a GAMEPAD_ADDED event for every pad that was already plugged in
+	// when the subsystem starts, so a pad opened by NativeInput_OpenKnownControllers
+	// gets announced again on the first pump. Without this check it would be handed
+	// a second, still-free slot and drive two players at once.
+	for (slot = 0; slot < NATIVE_INPUT_MAX_CONTROLLERS; slot++)
+	{
+		if ((s_controllers[slot].controller != NULL) && (s_controllers[slot].instanceId == (SDL_JoystickID)deviceIndex))
+		{
+			return slot;
+		}
+	}
+
 	for (slot = 0; slot < NATIVE_INPUT_MAX_CONTROLLERS; slot++)
 	{
 		if (s_controllerToSlotMapping[slot] == deviceIndex)
@@ -672,6 +702,12 @@ internal void NativeInput_CloseController(s32 slot)
 	controller->instanceId = -1;
 	controller->analogEnabled = 0;
 	controller->switchingAnalog = 0;
+	s_controllerToSlotMapping[slot] = -1;
+	s_padActTable[slot] = NULL;
+	s_padActLen[slot] = 0;
+	s_padRumbleLarge[slot] = 0;
+	s_padRumbleSmall[slot] = 0;
+	s_padRumbleSentMs[slot] = 0;
 
 	if (s_lastActiveControllerSlot == slot)
 	{
@@ -708,8 +744,13 @@ internal void NativeInput_OpenController(SDL_JoystickID instanceId, s32 slot)
 
 	joystick = SDL_GetGamepadJoystick(controller->controller);
 	controller->instanceId = joystick != NULL ? SDL_GetJoystickID(joystick) : instanceId;
-	controller->analogEnabled = 1;
+
+	// Real pads power up in digital mode with the analog LED off; the game
+	// switches them over itself through PadSetMainMode, and the player can
+	// toggle it by hand with Select+Start, standing in for the ANALOG button.
+	controller->analogEnabled = 0;
 	controller->switchingAnalog = 0;
+	s_controllerToSlotMapping[slot] = (s32)controller->instanceId;
 	NativeInput_MoveKeyboardOffControllerSlot(slot);
 }
 
@@ -791,6 +832,80 @@ void Platform_InputShutdown(void)
 	s_keyboardState = NULL;
 }
 
+// port encoding is libpad's: bits 4-5 pick the console socket, bits 0-1 the
+// multitap position inside it.
+internal s32 NativeInput_SlotForPort(int port)
+{
+	s32 physicalSlot = (port >> 4) & 1;
+	s32 tap = port & 3;
+	s32 slot;
+
+	if (NativeInput_UseMultitapBus() != 0)
+	{
+		if (physicalSlot != 0)
+		{
+			return -1;
+		}
+		slot = tap;
+	}
+	else
+	{
+		if (tap != 0)
+		{
+			return -1;
+		}
+		slot = physicalSlot;
+	}
+
+	if ((slot < 0) || (slot >= NATIVE_INPUT_MAX_CONTROLLERS))
+	{
+		return -1;
+	}
+
+	return slot;
+}
+
+// The MOT bytes ride along in every poll packet, so this runs once per frame
+// off whatever buffer PadSetAct latched, not once per PadSetAct call.
+// Byte 0 drives the small motor and is digital: only bit0 counts. Byte 1 is the
+// large motor's speed, 00h..FFh.
+internal void NativeInput_PushRumble(void)
+{
+	u64 now = SDL_GetTicks();
+	s32 slot;
+
+	for (slot = 0; slot < NATIVE_INPUT_MAX_CONTROLLERS; slot++)
+	{
+		struct NativeInputController *nativeController = &s_controllers[slot];
+		const u8 *table = s_padActTable[slot];
+		s32 len = s_padActLen[slot];
+		u16 large = 0;
+		u16 small = 0;
+
+		if (nativeController->controller == NULL)
+		{
+			continue;
+		}
+
+		if ((table != NULL) && (len > 0))
+		{
+			small = ((table[0] & 1) != 0) ? 0xffff : 0;
+			large = (len > 1) ? (u16)(table[1] * 257) : 0;
+		}
+
+		if ((large == s_padRumbleLarge[slot]) && (small == s_padRumbleSmall[slot]) &&
+		    ((large == 0 && small == 0) || ((now - s_padRumbleSentMs[slot]) < NATIVE_INPUT_RUMBLE_REARM_MS)))
+		{
+			continue;
+		}
+
+		s_padRumbleLarge[slot] = large;
+		s_padRumbleSmall[slot] = small;
+		s_padRumbleSentMs[slot] = now;
+		SDL_RumbleGamepad(nativeController->controller, large, small, NATIVE_INPUT_RUMBLE_DURATION_MS);
+	}
+}
+
 void Platform_InputUpdate(void)
 {
 	u16 keyboardButtons;
@@ -824,6 +939,7 @@ void Platform_InputUpdate(void)
 		NativeInput_ApplyKeyboard(slot, keyboardButtons);
 	}
 	NativeInput_WritePadBus();
+	NativeInput_PushRumble();
 }
 
 void Platform_InputControllerAdded(int deviceIndex)
@@ -891,33 +1007,66 @@ void Platform_InputPadInit(int slot, unsigned char *padData)
 
 int Platform_InputPadGetState(int port)
 {
-	s32 physicalSlot = (port >> 4) & 1;
-	s32 tap = port & 3;
-	s32 slot;
+	s32 slot = NativeInput_SlotForPort(port);
 
-	if (NativeInput_UseMultitapBus() != 0)
-	{
-		if (physicalSlot != 0)
-		{
-			return PadStateDiscon;
-		}
-		slot = tap;
-	}
-	else
-	{
-		if (tap != 0)
-		{
-			return PadStateDiscon;
-		}
-		slot = physicalSlot;
-	}
-
-	if ((slot < 0) || (slot >= NATIVE_INPUT_MAX_CONTROLLERS))
+	if (slot < 0)
 	{
 		return PadStateDiscon;
 	}
 
 	return s_controllers[slot].snapshot.connected ? PadStateStable : PadStateDiscon;
+}
+
+// Pad command 44h "Set LED State": offs 0 puts the pad back in digital mode
+// (LED off), offs 1 switches it to analog (LED red). Real pads power up in
+// digital mode, so this is what actually lights up the sticks.
+int Platform_InputPadSetMainMode(int port, int offs, int lock)
+{
+	s32 slot = NativeInput_SlotForPort(port);
+
+	(void)lock;
+
+	if (slot < 0)
+	{
+		return 0;
+	}
+
+	s_controllers[slot].analogEnabled = (offs != 0);
+	return 1;
+}
+
+int Platform_InputPadInfoAct(int port, int acno, int term)
+{
+	s32 slot = NativeInput_SlotForPort(port);
+	s32 count;
+
+	if (slot < 0)
+	{
+		return 0;
+	}
+
+	// A pad the host cannot shake has no actuators to report, same as a plain
+	// digital pad on hardware.
+	count = (s_controllers[slot].controller != NULL) ? NATIVE_INPUT_ACTUATOR_COUNT : 0;
+
+	if (acno < 0)
+	{
+		return count;
+	}
+
+	if (acno >= count)
+	{
+		return 0;
+	}
+
+	// Only InfoActCurr is ever asked for by the game; the remaining info bytes
+	// would need the pad's config-mode reply, which has no host equivalent.
+	if (term != NATIVE_INPUT_INFO_ACT_CURR)
+	{
+		return 0;
+	}
+
+	return (acno == 0) ? NATIVE_INPUT_ACTUATOR_CURR_SMALL : NATIVE_INPUT_ACTUATOR_CURR_LARGE;
 }
 
 int Platform_InputCapturePadSnapshots(struct PlatformInputPadSnapshot *dst, int count)
@@ -1054,55 +1203,18 @@ int Platform_InputRestoreState(const void *src, int srcSize)
 	return 1;
 }
 
+// PadSetAct only registers the buffer libpad keeps transmitting; the motors are
+// driven from NativeInput_PushRumble, once per poll, like the real MOT bytes.
 void Platform_InputPadVibrate(int port, unsigned char *table, int len)
 {
-	s32 physicalSlot = (port >> 4) & 1;
-	s32 tap = port & 3;
-	s32 slot;
-	struct NativeInputController *controller;
-	u16 freqHigh;
-	u16 freqLow;
+	s32 slot = NativeInput_SlotForPort(port);
 
-	if (NativeInput_UseMultitapBus() != 0)
-	{
-		if (physicalSlot != 0)
-		{
-			return;
-		}
-		slot = tap;
-	}
-	else
-	{
-		if (tap != 0)
-		{
-			return;
-		}
-		slot = physicalSlot;
-	}
-
-	if ((slot < 0) || (slot >= NATIVE_INPUT_MAX_CONTROLLERS) || (table == NULL) || (len <= 0))
+	if (slot < 0)
 	{
 		return;
 	}
 
-	controller = &s_controllers[slot];
-	if (controller->controller == NULL)
-	{
-		return;
-	}
-
-	freqHigh = table[0] * 255;
-	freqLow = len > 1 ? table[1] * 255 : 0;
-
-	if ((freqLow != 0) && (freqLow < 4096))
-	{
-		freqLow = 4096;
-	}
-
-	if ((freqHigh != 0) && (freqHigh < 4096))
-	{
-		freqHigh = 4096;
-	}
-
-	SDL_RumbleGamepad(controller->controller, freqLow, freqHigh, 200);
+	s_padActTable[slot] = table;
+	s_padActLen[slot] = (table != NULL) ? len : 0;
 }
+

--- a/platform/native_libgte.c
+++ b/platform/native_libgte.c
@@ -999,14 +999,21 @@ int SquareRoot0(int a)
 
 	lzcs &= 0xfffffffe;
 
+	/* Psy-Q 4.4 emits srav / sllv here, and a LOGICAL srl for the final >>12.
+	 * In C `a << n` is undefined for negative `a`, and `>>` on an int is
+	 * arithmetic rather than logical. Over the valid domain (a >= 0) both agree
+	 * - SQRT[] holds no entry >= 0x8000, so the intermediate is never negative
+	 * - but the helpers reproduce the exact instruction out of domain too, and
+	 * above all they stop the optimiser from exploiting the UB on the valid
+	 * path. */
 	if ((lzcs - 24) < 0)
 	{
-		idx = a >> (24 - lzcs);
+		idx = CTR_MipsSra(a, (u32)(24 - lzcs));
 	}
 	else
 	{
-		idx = a << (lzcs - 24);
+		idx = CTR_MipsSll(a, (u32)(lzcs - 24));
 	}
 
-	return SQRT[idx - 64] << ((31 - lzcs) >> 1) >> 12;
+	return (s32)CTR_MipsSrl(CTR_MipsSll(SQRT[idx - 64], (u32)((31 - lzcs) >> 1)), 12);
 }

--- a/platform/native_libgte.c
+++ b/platform/native_libgte.c
@@ -48,24 +48,30 @@ internal inline s32 fst_max(s32 a, s32 b)
 
 void InitGeom()
 {
-	C2_ZSF3 = 341;
-	C2_ZSF4 = 256;
-	C2_H = 1000;
-	C2_DQA = -98;
-	C2_DQB = 340;
-	C2_OFX = 0;
-	C2_OFY = 0;
+	/* Route through CTC2 like the hardware's ctc2 does. Assigning the C2_*
+	 * macros directly only touches the low half of the 16-bit control
+	 * registers, so DQA ended up readable as 0x0000FF9E where hardware
+	 * sign-extends it to 0xFFFFFF9E. Nothing reads those upper halves back
+	 * today, but SetDQA/SetDQB already use CTC2 - this makes the two agree. */
+	CTC2((u32)341, 29);      /* ZSF3 */
+	CTC2((u32)256, 30);      /* ZSF4 */
+	CTC2((u32)1000, 26);     /* H    */
+	CTC2((u32)(s32)-98, 27); /* DQA  */
+	CTC2((u32)340, 28);      /* DQB  */
+	CTC2(0, 24);             /* OFX  */
+	CTC2(0, 25);             /* OFY  */
 }
 
 void SetGeomOffset(int ofx, int ofy)
 {
-	C2_OFX = (ofx << 16);
-	C2_OFY = (ofy << 16);
+	/* `ofx << 16` is undefined in C for negative offsets; sll is not. */
+	CTC2((u32)CTR_MipsSll(ofx, 16), 24);
+	CTC2((u32)CTR_MipsSll(ofy, 16), 25);
 }
 
 void SetGeomScreen(int h)
 {
-	C2_H = h;
+	CTC2((u32)h, 26);
 }
 
 void SetRotMatrix(MATRIX *m)
@@ -860,7 +866,9 @@ void SetFogNear(int a, int h)
 {
 	// Error division by 0
 	assert(h != 0);
-	int depthQ = -(((a << 2) + a) << 6);
+	/* Shifts and negation in MIPS form: on R3000 these wrap, in C they are
+	 * undefined for negative / overflowing operands. */
+	int depthQ = CTR_MipsNegLo(CTR_MipsSll(CTR_MipsAddLo(CTR_MipsSll(a, 2), a), 6));
 	assert(h != -1 && depthQ != 0x8000);
 	SetDQA(depthQ / h);
 	SetDQB(20971520);
@@ -880,10 +888,12 @@ void SetFogNearFar(int a, int b, int h)
 	assert(h != 0);
 	assert(h != -1 && (((-a * b) / (b - a)) << 8) != 32768);
 
-	int dqa = (-a * b / (b - a) << 8) / h;
+	/* Same rewrite as SetFogNear. `-a * b` is a negu followed by mult/mflo on
+	 * hardware; both wrap there and are undefined in C. */
+	int dqa = CTR_MipsSll(CTR_MipsMulLo(CTR_MipsNegLo(a), b) / (b - a), 8) / h;
 
 	SetDQA(MAX(MIN(dqa, 32767), -32767));
-	SetDQB((b << 12) / (b - a) << 12);
+	SetDQB(CTR_MipsSll(CTR_MipsSll(b, 12) / (b - a), 12));
 }
 
 int rsin(int a)
@@ -920,25 +930,30 @@ int ratan2(int y, int x)
 		return 0;
 	}
 
+	/* MIPS semantics throughout: `-INT_MIN` and `INT_MIN << 10` are undefined
+	 * in C but perfectly defined on R3000 (both wrap). The guard below tests
+	 * bits 21..30 only, so INT_MIN slips past it and would reach the shift;
+	 * the Mips helpers reproduce exactly what the hardware yields (0), instead
+	 * of leaving the optimiser free to do something else. */
 	if (x < 0)
 	{
-		x = -x;
+		x = CTR_MipsNegLo(x);
 	}
 
 	if (y < 0)
 	{
-		y = -y;
+		y = CTR_MipsNegLo(y);
 	}
 
 	if (y < x)
 	{
 		if (((u32)y & 0x7fe00000U) == 0)
 		{
-			ang = (y << 10) / x;
+			ang = (u32)(CTR_MipsSll(y, 10) / x);
 		}
 		else
 		{
-			ang = y / (x >> 10);
+			ang = (u32)(y / CTR_MipsSra(x, 10));
 		}
 
 		v = ratan_tbl[ang];
@@ -947,11 +962,11 @@ int ratan2(int y, int x)
 	{
 		if (((u32)x & 0x7fe00000U) == 0)
 		{
-			ang = (x << 10) / y;
+			ang = (u32)(CTR_MipsSll(x, 10) / y);
 		}
 		else
 		{
-			ang = x / (y >> 10);
+			ang = (u32)(x / CTR_MipsSra(y, 10));
 		}
 
 		v = 1024 - ratan_tbl[ang];

--- a/platform/native_libpad.c
+++ b/platform/native_libpad.c
@@ -29,12 +29,12 @@ int PadGetState(int port)
 	return Platform_InputPadGetState(port);
 }
 
+// Retail libpad (SCUS_944.26 0x80075be0): returns the actuator count when acno
+// is negative, otherwise byte (term-1) of that actuator's 5-byte info record,
+// or 0 for an out-of-range actuator/term.
 int PadInfoAct(int port, int acno, int term)
 {
-	(void)port;
-	(void)acno;
-	(void)term;
-	return 0;
+	return Platform_InputPadInfoAct(port, acno, term);
 }
 
 int PadSetActAlign(int port, unsigned char *table)
@@ -44,14 +44,17 @@ int PadSetActAlign(int port, unsigned char *table)
 	return 1;
 }
 
+// Retail libpad (0x80075a40) queues pad command 44h "Set LED State" and returns
+// 1 when the request was accepted, 0 when the port is busy. Returning 0
+// unconditionally used to stall GAMEPAD_ProcessState at gamepadType 0, which is
+// why PadSetAct was never reached and rumble never ran.
 int PadSetMainMode(int socket, int offs, int lock)
 {
-	(void)socket;
-	(void)offs;
-	(void)lock;
-	return 0;
+	return Platform_InputPadSetMainMode(socket, offs, lock);
 }
 
+// Retail libpad (0x80075ba0) only latches the pointer and the length; the two
+// MOT bytes are then transmitted inside every poll packet, not once per call.
 void PadSetAct(int port, unsigned char *table, int len)
 {
 	Platform_InputPadVibrate(port, table, len);


### PR DESCRIPTION
So i did noticed some gameplay behavior on native felt different than playing on PS1 so i made a comparison against PS1 assembly searching for any difference on code or architecture that can be causing this like bugs or UB, MIPS CPU is not exactly like a PC after all, well i checked against the whole COLL, Vehicle (except VehTalk because i'm lazy lol), CAM, PlayLevel, GAMEPAD and 226 render overlay with the intention of finding any small hint about what is wrong in main gameplay flow, i found interesting stuff like a bug where some sub quads weren't rendering properly on certain cam angles, this was fixed on 226 on this PR, i also did a huge benchmark script for GTE, used psyq 4.4 source (ctr was built on that), psx-spx, sony official GTE manual and mednafen emulator source code to compare all possible results and find any UB or wrong logic present on the GTE implementation, when doing this an silent bug showed up where some instances somewhat far away (still visible on vistree) were rendering on screen if you were on certain world positions, turns out there was a unimplemented psx behavior where certain polygons aren't draw, check native gpu to see the fix, another of the bugs fixed there was one where the kart landing wasn't making the kart to bounce properly, that's mostly what this PR is for


PD: i also did checked the delta Timing increment (Timer.c), and some small changes on warpball and UI code related to wrong sign (the sign / size thing being something that also required changed headers) and a wrong assumption that ghosts / warpball icons on minimap used CRASH_BLUE instead of WHITE, verified by retail assembly.


- this PR is part 1, is fine to be merged but in the incoming days i'll also do this against MATH, PROC, Vector and other important functions related to physics